### PR TITLE
Fixed NPE when onEnterBlocked() is called during startup.

### DIFF
--- a/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorterQueueListener.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorterQueueListener.java
@@ -58,7 +58,11 @@ public class AdvancedQueueSorterQueueListener extends QueueListener {
 
 	@Override
 	public void onEnterBlocked(BlockedItem bi) {
-		QueueItemCache.get().getItem(bi.id).setBlocked();
+    ItemInfo item = QueueItemCache.get().getItem(bi.id);
+    // Null at startup
+    if (item != null) {
+      item.setBlocked();
+    }
 	}
 
 }


### PR DESCRIPTION
A NPE can happen if the throttle concurrent plugin is enabled and the queue is blocked.
