### PR TITLE
Avoid exceptions in log when optional plugin not installed

### DIFF
--- a/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/JobInclusionFolderProperty.java
+++ b/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/JobInclusionFolderProperty.java
@@ -62,7 +62,7 @@ public class JobInclusionFolderProperty extends FolderProperty<Folder> {
 		return (DescriptorImpl) super.getDescriptor();
 	}
 
-	@Extension
+	@Extension(optional = true)
 	public static final class DescriptorImpl extends FolderPropertyDescriptor {
 		
 		@Override


### PR DESCRIPTION
```
May 12, 2015 3:58:03 PM hudson.ExtensionFinder$Sezpoz _find
WARNING: Failed to load jenkins.advancedqueue.jobinclusion.strategy.JobInclusionFolderProperty$DescriptorImpl
java.lang.InstantiationException: java.lang.NoClassDefFoundError: com/cloudbees/hudson/plugins/folder/FolderPropertyDescriptor
	at net.java.sezpoz.IndexItem.element(IndexItem.java:146)
	at hudson.ExtensionFinder$Sezpoz._find(ExtensionFinder.java:625)
	at hudson.ExtensionFinder$Sezpoz.find(ExtensionFinder.java:614)
	at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:345)
	at hudson.ExtensionList.load(ExtensionList.java:300)
	at hudson.ExtensionList.ensureLoaded(ExtensionList.java:253)
	at hudson.ExtensionList.iterator(ExtensionList.java:143)
	at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:338)
	at hudson.ExtensionList.load(ExtensionList.java:300)
	at hudson.ExtensionList.ensureLoaded(ExtensionList.java:253)
	at hudson.ExtensionList.iterator(ExtensionList.java:143)
	at hudson.slaves.Channels.forProcess(Channels.java:110)
	at hudson.slaves.Channels.newJVM(Channels.java:228)
	at hudson.plugins.selenium.process.SeleniumProcessUtils.createSeleniumGridVM(SeleniumProcessUtils.java:54)
	at hudson.plugins.selenium.PluginImpl.startHub(PluginImpl.java:165)
	at hudson.plugins.selenium.PluginImpl.postInitialize(PluginImpl.java:151)
	at hudson.PluginManager$2$1$2.run(PluginManager.java:386)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:886)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NoClassDefFoundError: com/cloudbees/hudson/plugins/folder/FolderPropertyDescriptor
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:800)
	at jenkins.util.AntClassLoader.defineClassFromData(AntClassLoader.java:1138)
	at hudson.ClassicPluginStrategy$AntClassLoader2.defineClassFromData(ClassicPluginStrategy.java:758)
	at jenkins.util.AntClassLoader.getClassFromStream(AntClassLoader.java:1309)
	at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1365)
	at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1325)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at jenkins.ClassLoaderReflectionToolkit.invoke(ClassLoaderReflectionToolkit.java:44)
	at jenkins.ClassLoaderReflectionToolkit._findClass(ClassLoaderReflectionToolkit.java:86)
	at hudson.PluginManager$UberClassLoader.findClass(PluginManager.java:1110)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
	at net.java.sezpoz.IndexItem.element(IndexItem.java:134)
	... 24 more
Caused by: java.lang.ClassNotFoundException: com.cloudbees.hudson.plugins.folder.FolderPropertyDescriptor
	at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1375)
	at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1325)
	at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1078)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
	... 40 more
```