### PR TITLE
The selected value was inverted

### DIFF
--- a/src/main/resources/jenkins/advancedqueue/jobinclusion/strategy/JobInclusionJobProperty/config.jelly
+++ b/src/main/resources/jenkins/advancedqueue/jobinclusion/strategy/JobInclusionJobProperty/config.jelly
@@ -11,8 +11,8 @@
 			<f:entry title="Job Group" field="jobGroupName">
 				<select name="jobGroupName">
 					<j:forEach var="jobGroup" items="${descriptor.getJobGroups()}">
-			        	<f:option value="${jobGroup.value}" selected="${jobGroup.value != instance.jobGroupName}">${jobGroup.name}</f:option>
-				    </j:forEach>
+						<f:option value="${jobGroup.value}" selected="${jobGroup.value == instance.jobGroupName}">${jobGroup.name}</f:option>
+					</j:forEach>
 				</select>
 			</f:entry>
 		</f:optionalBlock>


### PR DESCRIPTION
I found another file where the select-attribute was inverted. I had forgot to look into all the `jelly.config` files.

This should be the last one.

I'm guessing I can link it to the same Jira-issue?
https://issues.jenkins-ci.org/browse/JENKINS-28280

Also, see #24 for the last Pull-Request.