### PR TITLE
adding build number priority strategy

### DIFF
--- a/src/main/java/jenkins/advancedqueue/priority/strategy/BuildNumberStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/BuildNumberStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013, Magnus Sandberg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.advancedqueue.priority.strategy;
+
+import hudson.Extension;
+import hudson.model.Queue;
+import hudson.model.Job;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author ...
+ * @since X.X
+ */
+public class BuildNumberStrategy extends AbstractDynamicPriorityStrategy {
+
+	@Extension
+	static public class BuildNumberStrategyDescriptor extends AbstractDynamicPriorityStrategyDescriptor {
+
+		public BuildNumberStrategyDescriptor() {
+			super("Use Priority from Build Number");
+		}
+	};
+
+	@DataBoundConstructor
+	public BuildNumberStrategy() {
+	}
+
+	public int getPriority(Queue.Item item) {
+		return ((Job)item.task).getNextBuildNumber();
+	}
+
+	@Override
+	public boolean isApplicable(Queue.Item item) {
+		return true;
+	}
+}

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/BuildNumberStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/BuildNumberStrategy.java
@@ -30,8 +30,8 @@ import hudson.model.Job;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * @author ...
- * @since X.X
+ * @author Bela Schaum
+ * @since 3.5
  */
 public class BuildNumberStrategy extends AbstractDynamicPriorityStrategy {
 

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/UpstreamCauseStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/UpstreamCauseStrategy.java
@@ -43,8 +43,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class UpstreamCauseStrategy extends AbstractDynamicPriorityStrategy {
 
 	@Extension
-	static public class BuildParameterStrategyDescriptor extends AbstractDynamicPriorityStrategyDescriptor {
-		public BuildParameterStrategyDescriptor() {
+	static public class UpstreamCauseStrategyDescriptor extends AbstractDynamicPriorityStrategyDescriptor {
+		public UpstreamCauseStrategyDescriptor() {
 			super("Job Triggered by a Upstream Build");
 		}
 	};

--- a/src/main/resources/jenkins/advancedqueue/priority/strategy/BuildNumberStrategy/config.jelly
+++ b/src/main/resources/jenkins/advancedqueue/priority/strategy/BuildNumberStrategy/config.jelly
@@ -1,0 +1,3 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
+	<f:description>Use the build number for priority.</f:description>
+</j:jelly>


### PR DESCRIPTION
The main idea is that when we have concurrent jobs (like competitors job in a competition) where matters the speed we need a priority that depends on how many builds was before now. 