### PR TITLE
[JENKINS-40284] - Fix blocked weights with FQ strategies

### DIFF
--- a/src/main/java/jenkins/advancedqueue/sorter/strategy/FQBaseStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/strategy/FQBaseStrategy.java
@@ -83,7 +83,7 @@ abstract public class FQBaseStrategy extends MultiBucketStrategy {
 		if (Float.POSITIVE_INFINITY == weight) {
 			maxStartedWeight = MIN_STARTED_WEIGHT;
 			prio2weight.clear();
-			return getWeightToUse(priority, minimumWeightToAssign);
+			return MIN_STARTED_WEIGHT;
 		}
 		return weight;
 	}

--- a/src/test/java/jenkins/advancedqueue/sorter/strategy/FQStrategyTest.java
+++ b/src/test/java/jenkins/advancedqueue/sorter/strategy/FQStrategyTest.java
@@ -1,8 +1,5 @@
 package jenkins.advancedqueue.sorter.strategy;
 
-import jenkins.advancedqueue.sorter.strategy.FQBaseStrategy;
-import jenkins.advancedqueue.sorter.strategy.FQStrategy;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -19,7 +16,17 @@ public class FQStrategyTest {
 	@Test
 	public void testGetWeightToUse() {
 		Assert.assertEquals(1.00000F + FQBaseStrategy.MIN_STEP_SIZE, new FQStrategy().getWeightToUse(1, 1.00000F), 0F);
-		Assert.assertEquals(4.56456F + FQBaseStrategy.MIN_STEP_SIZE, new FQStrategy().getWeightToUse(2, 4.56456F), 0F);
+		Assert.assertEquals(1.00001F + FQBaseStrategy.MIN_STEP_SIZE, new FQStrategy().getWeightToUse(1, 1.00001F), 0F);
+		assertIncreasingWeight(1F);
+		assertIncreasingWeight(100000F);
 	}
 
+	private void assertIncreasingWeight(float initialWeight) {
+		float previousWeight = initialWeight;
+		for (int i = 0; i < 10; ++i) {
+			float newWeight = new FQStrategy().getWeightToUse(1, previousWeight);
+			Assert.assertTrue(String.format("New weight %s should be greater than previous weight %s", newWeight, previousWeight), newWeight > previousWeight);
+			previousWeight = newWeight;
+		}
+	}
 }

--- a/src/test/java/jenkins/advancedqueue/sorter/strategy/FQStrategyTest.java
+++ b/src/test/java/jenkins/advancedqueue/sorter/strategy/FQStrategyTest.java
@@ -17,6 +17,7 @@ public class FQStrategyTest {
 	public void testGetWeightToUse() {
 		Assert.assertEquals(1.00000F + FQBaseStrategy.MIN_STEP_SIZE, new FQStrategy().getWeightToUse(1, 1.00000F), 0F);
 		Assert.assertEquals(1.00001F + FQBaseStrategy.MIN_STEP_SIZE, new FQStrategy().getWeightToUse(1, 1.00001F), 0F);
+		Assert.assertEquals(1F, new FQStrategy().getWeightToUse(1, Float.MAX_VALUE), 0F);
 		assertIncreasingWeight(1F);
 		assertIncreasingWeight(100000F);
 	}

--- a/src/test/java/jenkins/advancedqueue/sorter/strategy/WFQStrategyTest.java
+++ b/src/test/java/jenkins/advancedqueue/sorter/strategy/WFQStrategyTest.java
@@ -1,8 +1,5 @@
 package jenkins.advancedqueue.sorter.strategy;
 
-import jenkins.advancedqueue.sorter.strategy.FQBaseStrategy;
-import jenkins.advancedqueue.sorter.strategy.WFQStrategy;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -19,10 +16,10 @@ public class WFQStrategyTest {
 	
 	@Test
 	public void testGetWeightToUse() {
-		Assert.assertEquals(FQBaseStrategy.MIN_STEP_SIZE * 1 * 456456, new WFQStrategy().getWeightToUse(1, 4.56455F), 0F);
-		Assert.assertEquals(FQBaseStrategy.MIN_STEP_SIZE * 2 * 228228, new WFQStrategy().getWeightToUse(2, 4.56455F), 0F);
-		Assert.assertEquals(FQBaseStrategy.MIN_STEP_SIZE * 3 * 152152, new WFQStrategy().getWeightToUse(3, 4.56455F), 0F);
+		Assert.assertEquals(1.00000F + FQBaseStrategy.MIN_STEP_SIZE, new WFQStrategy().getWeightToUse(1, 1.00000F), 0F);
+		Assert.assertEquals(1.00001F + FQBaseStrategy.MIN_STEP_SIZE, new WFQStrategy().getWeightToUse(1, 1.00001F), 0F);
+		Assert.assertEquals(1.00000F + 2*FQBaseStrategy.MIN_STEP_SIZE, new WFQStrategy().getWeightToUse(2, 1.00000F), 0F);
+		Assert.assertEquals(1.00001F + 2*FQBaseStrategy.MIN_STEP_SIZE, new WFQStrategy().getWeightToUse(2, 1.00001F), 0F);
 	}
-
 	
 }


### PR DESCRIPTION
When a weight reached 1.00005 for instance, it was never increased
due to the comparison on floats.
Also, the weight was no more increased when the step became too small
compared to the minimum weight. As we are not using integers but
floats, the step must remain proportional to the weight.
