### PR TITLE
[JENKINS-40284] Fixed FQ weight calculation.

### DIFF
--- a/src/main/java/jenkins/advancedqueue/sorter/strategy/FQBaseStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/strategy/FQBaseStrategy.java
@@ -73,7 +73,7 @@ abstract public class FQBaseStrategy extends MultiBucketStrategy {
 
 	protected float getWeightToUse(int priority, float minimumWeightToAssign) {
 		float stepSize = getStepSize(priority);
-		double weight = Math.ceil(minimumWeightToAssign / stepSize) * stepSize;
+		float weight = (float) Math.ceil(minimumWeightToAssign / stepSize) * stepSize;
 		// Cannot be smaller but maybe rounding problems (?)
 		if (weight <= minimumWeightToAssign) {
 			weight += stepSize;
@@ -88,7 +88,7 @@ abstract public class FQBaseStrategy extends MultiBucketStrategy {
 			prio2weight.clear();
 			return getWeightToUse(priority, minimumWeightToAssign);
 		}
-		return (float) weight;
+		return weight;
 	}
 
 	abstract float getStepSize(int priority);


### PR DESCRIPTION
A (double) _weight_ is compared to a floating _minimumWeightToAssign_ value which causes the _weigh_ to cap to a certain value and to never be incremented. As demonstrated in a test in https://issues.jenkins-ci.org/browse/JENKINS-40284

@reviewbybees 