### PR TITLE
[JENKINS-36570] - Cleanup references to AbstractProject in the core plugin classes

### DIFF
--- a/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
@@ -24,13 +24,14 @@
 package jenkins.advancedqueue;
 
 import hudson.Extension;
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import jenkins.advancedqueue.JobGroup.PriorityStrategyHolder;
@@ -148,24 +149,24 @@ public class PrioritySorterConfiguration extends GlobalConfiguration {
 		SecurityContext saveCtx = ACL.impersonate(ACL.SYSTEM);
 		try {
 			@SuppressWarnings("rawtypes")
-			List<AbstractProject> allProjects = Jenkins.getInstance().getAllItems(AbstractProject.class);
-			for (AbstractProject<?, ?> project : allProjects) {
+			List<Job> allJobs = Jenkins.getInstance().getAllItems(Job.class);
+			for (Job<?, ?> job : allJobs) {
 				try {
 					// Scale any priority on the Job
-					PriorityJobProperty priorityProperty = project
+					PriorityJobProperty priorityProperty = job
 							.getProperty(PriorityJobProperty.class);
 					if (priorityProperty != null && priorityProperty.getUseJobPriority()) {
 						int newPriority = PriorityCalculationsUtil.scale(prevNumberOfPriorities,
 								strategy.getNumberOfPriorities(), priorityProperty.priority);
                         if (newPriority != priorityProperty.getPriority()) {
-                            project.removeProperty(priorityProperty);
-                            project.addProperty(new PriorityJobProperty(priorityProperty.getUseJobPriority(),
+                            job.removeProperty(priorityProperty);
+                            job.addProperty(new PriorityJobProperty(priorityProperty.getUseJobPriority(),
                                     newPriority));
-                            project.save();
+                            job.save();
                         }
 					}
 				} catch (IOException e) {
-					LOGGER.warning("Failed to update Advanced Job Priority To " + project.getName());
+					LOGGER.log(Level.WARNING, "Failed to update Advanced Job Priority To {0}", job.getName());
 				}
 			}
 			//

--- a/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/JobInclusionJobProperty.java
+++ b/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/JobInclusionJobProperty.java
@@ -24,7 +24,7 @@
 package jenkins.advancedqueue.jobinclusion.strategy;
 
 import hudson.Extension;
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.util.ListBoxModel;
@@ -35,7 +35,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @author Magnus Sandberg
  * @since 3.0
  */
-public class JobInclusionJobProperty extends JobProperty<AbstractProject<?, ?>> {
+public class JobInclusionJobProperty extends JobProperty<Job<?, ?>> {
 
 	private boolean useJobGroup;
 

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/PriorityJobProperty.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/PriorityJobProperty.java
@@ -50,7 +50,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * @author Magnus Sandberg
  * @since 2.0
  */
-public class PriorityJobProperty extends JobProperty<AbstractProject<?, ?>> {
+public class PriorityJobProperty extends JobProperty<Job<?, ?>> {
 
 	private final static Logger LOGGER = Logger.getLogger(PriorityJobProperty.class.getName());
 


### PR DESCRIPTION
Generally this change is not binary compatible, and likely it requires 4.0. Not sure if the plugin can be really used in Pipeline without this fix. 

https://issues.jenkins-ci.org/browse/JENKINS-36570

CC @reviewbybees, @vitalii-vitrenko and @timothyclarke