### PR TITLE
[JENKINS-41419] Fix comparison of ItemInfo objects

### DIFF
--- a/src/main/java/jenkins/advancedqueue/sorter/ItemInfo.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/ItemInfo.java
@@ -153,7 +153,7 @@ public class ItemInfo implements PriorityConfigurationCallback, DecisionLogger, 
 			if(this.getSortableInQueueSince() == o.getSortableInQueueSince()) {
 				return new Integer(this.getItemId()).compareTo(o.getItemId());
 			}
-			return new Long(this.getInQueueSince()).compareTo(o.getInQueueSince());
+			return new Long(this.getSortableInQueueSince()).compareTo(o.getSortableInQueueSince());
 		}
 		return Float.compare(this.getWeight(), o.getWeight());
 	}


### PR DESCRIPTION
If an ``ItemInfo`` object has the ``sortAsInQueueSince`` attribute set, the ``compareTo()`` method is not working correctly anymore.

The check, if we can sort by the InQueueSince time, is correctly using the ``getSortableInQueueSince()`` method, which includes the ``sortAsInQueueSince`` attribute and the ``inQueueSince`` attribute.

However, the actually comparison does not use this function and uses ``getInQueueSince()`` instead. Because of that the ``sortAsInQueueSince`` attribute is ignored and the objects are compared wrongly, leading to a wrongly sorted build queue.

Fix it using the ``getSortableInQueueSince()`` method not only in the check but also in the comparison.
