### PR TITLE
Annotate methods which return explicit null

### DIFF
--- a/src/main/java/jenkins/advancedqueue/JobGroup.java
+++ b/src/main/java/jenkins/advancedqueue/JobGroup.java
@@ -25,6 +25,7 @@ package jenkins.advancedqueue;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.CheckForNull;
 
 import jenkins.advancedqueue.jobinclusion.JobInclusionStrategy;
 import jenkins.advancedqueue.jobinclusion.strategy.ViewBasedJobInclusionStrategy;
@@ -139,6 +140,7 @@ public class JobGroup {
 	 * @deprecated Used in 2.x now replaced with dynamic {@link JobGroup#jobGroupStrategy}, will return the view
 	 */
 	@Deprecated
+        @CheckForNull
 	public String getView() {
 		if(jobGroupStrategy instanceof ViewBasedJobInclusionStrategy) {
 			return ((ViewBasedJobInclusionStrategy) jobGroupStrategy).getViewName();

--- a/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
@@ -53,6 +53,8 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 import javax.servlet.ServletException;
 
@@ -236,7 +238,8 @@ public class PriorityConfiguration extends Descriptor<PriorityConfiguration> imp
 		return priorityCallback.setPrioritySelection(PrioritySorterConfiguration.get().getStrategy().getDefaultPriority());
 	}
 
-	public JobGroup getJobGroup(PriorityConfigurationCallback priorityCallback, Job<?, ?> job) {
+        @CheckForNull
+	public JobGroup getJobGroup(@Nonnull PriorityConfigurationCallback priorityCallback, @Nonnull Job<?, ?> job) {
 		if (!(job instanceof TopLevelItem)) {
 			priorityCallback.addDecisionLog(0, "Job is not a TopLevelItem [" + job.getClass().getName() + "] ...");
 			return null;

--- a/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/FolderPropertyLoader.java
+++ b/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/FolderPropertyLoader.java
@@ -33,6 +33,7 @@ import hudson.util.DescribableList;
 import jenkins.advancedqueue.DecisionLogger;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
+import javax.annotation.CheckForNull;
 
 /**
  * @author Magnus Sandberg
@@ -40,6 +41,7 @@ import com.cloudbees.hudson.plugins.folder.Folder;
  */
 public class FolderPropertyLoader {
 
+	@CheckForNull    
 	static public String getJobGroupName(DecisionLogger decisionLogger, Job<?, ?> job) {
 		ItemGroup<?> parent = job.getParent();
 		decisionLogger.addDecisionLog(2, "Checking for Cloudbees Folder inclusion ...");

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/BuildParameterStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/BuildParameterStrategy.java
@@ -29,6 +29,9 @@ import hudson.model.Queue;
 import hudson.model.StringParameterValue;
 
 import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.advancedqueue.PrioritySorterConfiguration;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -57,7 +60,8 @@ public class BuildParameterStrategy extends AbstractDynamicPriorityStrategy {
 		return parameterName;
 	}
 
-	private Integer getPriorityInternal(Queue.Item item) {
+	@CheckForNull
+	private Integer getPriorityInternal(@Nonnull Queue.Item item) {
 		List<ParametersAction> actions = item.getActions(ParametersAction.class);
 		for (ParametersAction action : actions) {
 			StringParameterValue parameterValue = (StringParameterValue) action.getParameter(parameterName);
@@ -73,12 +77,18 @@ public class BuildParameterStrategy extends AbstractDynamicPriorityStrategy {
 		return null;
 	}
 
-	public int getPriority(Queue.Item item) {
-		return getPriorityInternal(item);
+	/**
+	 * Gets priority of the queue item.
+	 * @param item Queue item
+	 * @return Priority if it can be determined. Default priority otherwise
+	 */
+	public int getPriority(@Nonnull Queue.Item item) {
+		final Integer p = getPriorityInternal(item);
+		return p != null ? p : PrioritySorterConfiguration.get().getStrategy().getDefaultPriority();
 	}
 
 	@Override
-	public boolean isApplicable(Queue.Item item) {
+	public boolean isApplicable(@Nonnull Queue.Item item) {
 		return getPriorityInternal(item) != null;
 	}
 }

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/JobPropertyStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/JobPropertyStrategy.java
@@ -27,6 +27,8 @@ import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Queue.Item;
+import javax.annotation.CheckForNull;
+import jenkins.advancedqueue.PrioritySorterConfiguration;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -49,7 +51,7 @@ public class JobPropertyStrategy extends AbstractDynamicPriorityStrategy {
 	public JobPropertyStrategy() {
 	}
 	
-
+	@CheckForNull
 	private Integer getPriorityInternal(Queue.Item item) {
 		if(item.task instanceof Job<?, ?>) {
 			Job<?, ?> job = (Job<?, ?>) item.task;
@@ -68,7 +70,8 @@ public class JobPropertyStrategy extends AbstractDynamicPriorityStrategy {
 
 	@Override
 	public int getPriority(Item item) {
-		return getPriorityInternal(item);
+		final Integer p = getPriorityInternal(item);
+		return p != null ? p : PrioritySorterConfiguration.get().getStrategy().getDefaultPriority();
 	}
 
 }

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/UpstreamCauseStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/UpstreamCauseStrategy.java
@@ -29,6 +29,8 @@ import hudson.model.Cause.UpstreamCause;
 import hudson.model.Queue;
 
 import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 import jenkins.advancedqueue.PrioritySorterConfiguration;
 import jenkins.advancedqueue.sorter.ItemInfo;
@@ -54,7 +56,8 @@ public class UpstreamCauseStrategy extends AbstractDynamicPriorityStrategy {
 	public UpstreamCauseStrategy() {
 	}
 
-	private UpstreamCause getUpstreamCause(Queue.Item item) {
+	@CheckForNull
+	private UpstreamCause getUpstreamCause(@Nonnull Queue.Item item) {
 		List<Cause> causes = item.getCauses();
 		for (Cause cause : causes) {
 			if (cause.getClass() == UpstreamCause.class) {
@@ -66,6 +69,11 @@ public class UpstreamCauseStrategy extends AbstractDynamicPriorityStrategy {
 
 	public int getPriority(Queue.Item item) {
 		UpstreamCause upstreamCause = getUpstreamCause(item);
+                if (upstreamCause == null) {
+                    // Cannot determine
+                    return PrioritySorterConfiguration.get().getStrategy().getDefaultPriority();
+                }
+                
 		String upstreamProject = upstreamCause.getUpstreamProject();
 		int upstreamBuildId = upstreamCause.getUpstreamBuild();
 		ItemInfo upstreamItem = StartedJobItemCache.get().getStartedItem(upstreamProject, upstreamBuildId);

--- a/src/main/java/jenkins/advancedqueue/sorter/SorterStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/SorterStrategy.java
@@ -30,6 +30,7 @@ import hudson.model.Queue.LeftItem;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import jenkins.model.Jenkins;
@@ -95,6 +96,7 @@ public abstract class SorterStrategy extends ExtensionPoint implements Describab
 		return strategies;
 	}
 
+	@CheckForNull
 	public static SorterStrategyDescriptor getSorterStrategy(String key) {
 		List<SorterStrategyDescriptor> allSorterStrategies = getAllSorterStrategies();
 		for (SorterStrategyDescriptor sorterStrategy : allSorterStrategies) {
@@ -105,6 +107,7 @@ public abstract class SorterStrategy extends ExtensionPoint implements Describab
 		return null;
 	}
 
+	@CheckForNull
 	public static SorterStrategy getPrioritySorterStrategy(SorterStrategyDescriptor sorterStrategy) {
 		ExtensionList<SorterStrategy> all = all();
 		for (SorterStrategy prioritySorterStrategy : all) {

--- a/src/main/java/jenkins/advancedqueue/sorter/strategy/MultiBucketStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/strategy/MultiBucketStrategy.java
@@ -26,6 +26,7 @@ package jenkins.advancedqueue.sorter.strategy;
 import hudson.util.ListBoxModel;
 
 import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 import javax.servlet.ServletException;
 
@@ -98,6 +99,7 @@ public abstract class MultiBucketStrategy extends SorterStrategy {
 			return items;
 		}
 
+		@CheckForNull
 		private MultiBucketStrategy getStrategy() {
 			SorterStrategy strategy = PrioritySorterConfiguration.get().getStrategy();
 			if (strategy == null || !(strategy instanceof MultiBucketStrategy)) {

--- a/src/test/java/jenkins/advancedqueue/test/UpstreamTest.java
+++ b/src/test/java/jenkins/advancedqueue/test/UpstreamTest.java
@@ -13,6 +13,7 @@ import org.jvnet.hudson.test.recipes.LocalData;
 import hudson.model.Cause;
 import hudson.model.Cause.UpstreamCause;
 import hudson.model.Cause.UserIdCause;
+import javax.annotation.CheckForNull;
 import jenkins.advancedqueue.testutil.ExpectedItem;
 import jenkins.advancedqueue.testutil.JobHelper;
 import jenkins.advancedqueue.testutil.TestRunListener;
@@ -56,6 +57,7 @@ public class UpstreamTest {
 		TestRunListener.assertStartedItems();
 	}
 
+	@CheckForNull
 	private UpstreamCause createUpstreamCause(final String upstreamProject, final int upstreamBuild) throws Exception {
 		final Class<?> clazz = UpstreamCause.class;
 		final Constructor<?>[] constructors = clazz.getDeclaredConstructors();


### PR DESCRIPTION
There is a risk of NPEs in some cases, e.g. in "*Strategy#getPriority()" API. No related JIRA issues, but I would rather fix it.