### PR TITLE
Fix UI bindings for strategies provided by other plugins

### DIFF
--- a/src/main/resources/jenkins/advancedqueue/PriorityConfiguration/index.jelly
+++ b/src/main/resources/jenkins/advancedqueue/PriorityConfiguration/index.jelly
@@ -53,7 +53,7 @@
 												<j:set var="descriptor" value="${instance.descriptor}" />
 												<f:entry title="${descriptor.displayName}">
   													<input type="hidden" name="stapler-class" value="${descriptor.clazz.name}"/>
-													<st:include page="${descriptor.configPage}" />
+													<st:include it="${instance}" page="${descriptor.configPage}" />
 												</f:entry>
 											</j:if>										
 											<f:entry>


### PR DESCRIPTION
`st:include` with `it` attr does work for all strategies provided by the priority-sorter plugin (and accessible through its classloader), but config pages for any strategies provided by other plugins would not be found.