### PR TITLE
Fix for view based priority sorting jelly

### DIFF
--- a/src/main/resources/jenkins/advancedqueue/jobinclusion/strategy/ViewBasedJobInclusionStrategy/config.jelly
+++ b/src/main/resources/jenkins/advancedqueue/jobinclusion/strategy/ViewBasedJobInclusionStrategy/config.jelly
@@ -5,11 +5,11 @@
 			<j:forEach var="view" items="${descriptor.listViewItems}">
 				<f:option value="${view.value}" selected="${view.value==instance.viewName}">${view.name}</f:option>
 			</j:forEach>
-			<f:optionalBlock name="jobFilter" checked="${instance.useJobFilter}" title="${%Use a regular expression to only include a subset of the included Jobs}">
-				<f:entry title="${%Regular Expression}">
-					<f:textbox name="jobPattern" field="jobPattern" value="${instance.jobPattern}" />
-				</f:entry>           					
-	    	</f:optionalBlock>			
 		</select>
+        <f:optionalBlock name="jobFilter" checked="${instance.useJobFilter}" title="${%Use a regular expression to only include a subset of the included Jobs}">
+            <f:entry title="${%Regular Expression}">
+                <f:textbox name="jobPattern" field="jobPattern" value="${instance.jobPattern}" />
+            </f:entry>
+        </f:optionalBlock>
 	</f:entry>
 </j:jelly>


### PR DESCRIPTION
**What was wrong**
In Jenkins - starting from version 2.264 - it was not possible to add or make changes to priority sorter for "Jobs included in a view".
Format of data in a json was not handled properly.

**What has been done**
Structure of elements in UI was wrong. The part of the UI responsible for filtering based on regular expression was placed inside views selector.

**How to test**
1. Install Jenkins version 2.264-2.277
2. Go to Job Priority and Add new priority sorter
3. Set "Jobs to include" to "Jobs included in a view"
4. Save changes
The test will result in "Oops!" page while using Priority Sorter plugin in version 4.0 and will work fine with the fixed version.

It has been tested and works fine on Jenkins 2.263.4 and 2.277.2