### PR TITLE
[JENKINS-66938] Allow 2 or more priority definitions to be saved

### DIFF
--- a/src/main/java/jenkins/advancedqueue/PriorityConfigurationPlaceholderTaskHelper.java
+++ b/src/main/java/jenkins/advancedqueue/PriorityConfigurationPlaceholderTaskHelper.java
@@ -8,6 +8,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import jenkins.advancedqueue.sorter.ItemInfo;
 import jenkins.advancedqueue.sorter.QueueItemCache;
+import jenkins.advancedqueue.sorter.strategy.MultiBucketStrategy;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
 
@@ -28,7 +29,11 @@ class PriorityConfigurationPlaceholderTaskHelper {
             if (itemInfo != null) {
                 priorityCallback.setPrioritySelection(itemInfo.getPriority());
             } else {
-                priorityCallback.setPrioritySelection(PrioritySorterConfiguration.get().getStrategy().getDefaultPriority());
+                if (PrioritySorterConfiguration.get() != null && PrioritySorterConfiguration.get().getStrategy() != null) {
+		   priorityCallback.setPrioritySelection(PrioritySorterConfiguration.get().getStrategy().getDefaultPriority());
+		} else {
+		   priorityCallback.setPrioritySelection(MultiBucketStrategy.DEFAULT_PRIORITY);
+		}
             }
         } else {
             if (LOGGER.isLoggable(Level.FINE)) {

--- a/src/main/resources/jenkins/advancedqueue/PriorityConfiguration/index.jelly
+++ b/src/main/resources/jenkins/advancedqueue/PriorityConfiguration/index.jelly
@@ -41,7 +41,7 @@
 									<f:dropdownDescriptorSelector title="${%Jobs to include}" field="jobGroupStrategy" descriptors="${it.jobInclusionStrategyDescriptors}"/>
 								</f:entry>
 								<f:entry title="Priority">
-									<select name="priority" class="setting-input dropdownList">
+									<select name="priority">
 										<j:forEach var="priority" items="${it.priorities}">
 											<j:if test="${priority.value == jobGroup.priority}">
 												<f:option value="${priority.value}" selected="true">${priority.name}</f:option>

--- a/src/main/resources/jenkins/advancedqueue/jobinclusion/strategy/FolderBasedJobInclusionStrategy/config.jelly
+++ b/src/main/resources/jenkins/advancedqueue/jobinclusion/strategy/FolderBasedJobInclusionStrategy/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
 	<f:entry title="${%Apply to Jobs in Folder}">
-		<select name="folderName" class="setting-input dropdownList">
+		<select name="folderName">
 			<j:forEach var="folder" items="${descriptor.listFolderItems}">
 				<f:option value="${folder.value}" selected="${folder.value==instance.folderName}">${folder.name}</f:option>
 			</j:forEach>

--- a/src/main/resources/jenkins/advancedqueue/jobinclusion/strategy/ViewBasedJobInclusionStrategy/config.jelly
+++ b/src/main/resources/jenkins/advancedqueue/jobinclusion/strategy/ViewBasedJobInclusionStrategy/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
 	<f:entry title="${%Apply to Jobs in View}">
-		<select name="viewName" class="setting-input dropdownList">
+		<select name="viewName">
 			<j:forEach var="view" items="${descriptor.listViewItems}">
 				<f:option value="${view.value}" selected="${view.value==instance.viewName}">${view.name}</f:option>
 			</j:forEach>


### PR DESCRIPTION
## [JENKINS-66938](https://issues.jenkins.io/browse/JENKINS-66938) Save non-trivial priority definitions

* Fix for view based priority sorting jelly
* [JENKINS-66938] Allow save of 2+ priority definitions

Special thanks to @monluk for the April 2021 fix to one of the issues discovered here.

See also:

* [JENKINS-67218](https://issues.jenkins.io/browse/JENKINS-67218) - Unable to store priority sorter configuration
* [JENKINS-65859](https://issues.jenkins.io/browse/JENKINS-65859) - "Priority Sorter Plugin" broken in 2.277.4 (though this fix does not resolve the issue described in that report)