### PR TITLE
Add deeper spotbugs checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <gitHubRepo>jenkinsci/priority-sorter-plugin</gitHubRepo>
         <jenkins.version>2.235.4</jenkins.version>
         <java.level>8</java.level>
+        <spotbugs.effort>Max</spotbugs.effort>
     </properties>
     <artifactId>PrioritySorter</artifactId>
 	<version>${revision}${changelist}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <jenkins.version>2.235.4</jenkins.version>
         <java.level>8</java.level>
         <spotbugs.effort>Max</spotbugs.effort>
+        <spotbugs.threshold>Low</spotbugs.threshold>
     </properties>
     <artifactId>PrioritySorter</artifactId>
 	<version>${revision}${changelist}</version>

--- a/src/main/java/jenkins/advancedqueue/ItemTransitionLogger.java
+++ b/src/main/java/jenkins/advancedqueue/ItemTransitionLogger.java
@@ -23,12 +23,12 @@
  */
 package jenkins.advancedqueue;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
 
 import jenkins.advancedqueue.sorter.ItemInfo;
-import jenkins.model.Jenkins;
 
 /**
  * @author Magnus Sandberg
@@ -38,7 +38,7 @@ public class ItemTransitionLogger {
 
 	private final static Logger LOGGER = Logger.getLogger("PrioritySorter.Queue.Items");
 
-	static public void logNewItem(@Nonnull ItemInfo info) {
+	static public void logNewItem(@NonNull ItemInfo info) {
 		if (LOGGER.isLoggable(Level.FINER)) {
 			LOGGER.finer("New Item: " + info.toString() + "\n" + info.getDescisionLog());
 		} else {
@@ -46,19 +46,19 @@ public class ItemTransitionLogger {
 		}
 	}
 
-	static public void logBlockedItem(@Nonnull ItemInfo info) {
+	static public void logBlockedItem(@NonNull ItemInfo info) {
 		LOGGER.fine("Blocking: " + info.toString());
 	}
 
-	static public void logBuilableItem(@Nonnull ItemInfo info) {
+	static public void logBuilableItem(@NonNull ItemInfo info) {
 		LOGGER.fine("Buildable: " + info.toString());
 	}
 
-	static public void logStartedItem(@Nonnull ItemInfo info) {
+	static public void logStartedItem(@NonNull ItemInfo info) {
 		LOGGER.fine("Starting: " + info.toString());
 	}
 
-	static public void logCanceledItem(@Nonnull ItemInfo info) {
+	static public void logCanceledItem(@NonNull ItemInfo info) {
 		LOGGER.fine("Canceling: " + info.toString());
 	}
 

--- a/src/main/java/jenkins/advancedqueue/JobGroup.java
+++ b/src/main/java/jenkins/advancedqueue/JobGroup.java
@@ -23,13 +23,14 @@
  */
 package jenkins.advancedqueue;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.CheckForNull;
 
 import jenkins.advancedqueue.jobinclusion.JobInclusionStrategy;
 import jenkins.advancedqueue.jobinclusion.strategy.ViewBasedJobInclusionStrategy;
-import javax.annotation.Nonnull;
 
 import jenkins.advancedqueue.priority.PriorityStrategy;
 import net.sf.json.JSONArray;
@@ -119,7 +120,7 @@ public class JobGroup {
 		this.id = id;
 	}
 
-    public @Nonnull String getDescription() {
+    public @NonNull String getDescription() {
         return hudson.Util.fixNull(description);
     }
 

--- a/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
@@ -23,6 +23,9 @@
  */
 package jenkins.advancedqueue;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.ExtensionList;
@@ -51,8 +54,6 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 
 import javax.servlet.ServletException;
 
@@ -235,7 +236,7 @@ public class PriorityConfiguration extends Descriptor<PriorityConfiguration> imp
 	}
 
         @CheckForNull
-	public JobGroup getJobGroup(@Nonnull PriorityConfigurationCallback priorityCallback, @Nonnull Job<?, ?> job) {
+	public JobGroup getJobGroup(@NonNull PriorityConfigurationCallback priorityCallback, @NonNull Job<?, ?> job) {
 		if (!(job instanceof TopLevelItem)) {
 			priorityCallback.addDecisionLog(0, "Job is not a TopLevelItem [" + job.getClass().getName() + "] ...");
 			return null;

--- a/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
@@ -46,7 +46,6 @@ import hudson.util.ListBoxModel;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
@@ -89,20 +89,12 @@ public class PriorityConfiguration extends Descriptor<PriorityConfiguration> imp
 		jobGroups = new LinkedList<JobGroup>();
 		load();
 		//
-		Collections.sort(jobGroups, new Comparator<JobGroup>() {
-			public int compare(JobGroup o1, JobGroup o2) {
-				return o1.getId() - o2.getId();
-			}
-		});
+		Collections.sort(jobGroups, (JobGroup o1, JobGroup o2) -> o1.getId() - o2.getId());
 		//
 		id2jobGroup = new HashMap<Integer, JobGroup>();
 		for (JobGroup jobGroup : jobGroups) {
 			id2jobGroup.put(jobGroup.getId(), jobGroup);
-			Collections.sort(jobGroup.getPriorityStrategies(), new Comparator<JobGroup.PriorityStrategyHolder>() {
-				public int compare(JobGroup.PriorityStrategyHolder o1, JobGroup.PriorityStrategyHolder o2) {
-					return o1.getId() - o2.getId();
-				}
-			});
+			Collections.sort(jobGroup.getPriorityStrategies(), (JobGroup.PriorityStrategyHolder o1, JobGroup.PriorityStrategyHolder o2) -> o1.getId() - o2.getId());
 		}
 		//
 		Plugin plugin = Jenkins.get().getPlugin("matrix-project");

--- a/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
@@ -28,7 +28,6 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.Plugin;
 import hudson.matrix.MatrixConfiguration;
-import hudson.matrix.MatrixProject;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Job;
@@ -38,7 +37,6 @@ import hudson.model.TopLevelItem;
 import hudson.model.ViewGroup;
 import hudson.model.View;
 import hudson.security.ACL;
-import hudson.security.Permission;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
@@ -60,8 +58,6 @@ import javax.servlet.ServletException;
 
 import jenkins.advancedqueue.jobinclusion.JobInclusionStrategy;
 import jenkins.advancedqueue.priority.PriorityStrategy;
-import jenkins.advancedqueue.sorter.ItemInfo;
-import jenkins.advancedqueue.sorter.QueueItemCache;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;

--- a/src/main/java/jenkins/advancedqueue/PriorityConfigurationPlaceholderTaskHelper.java
+++ b/src/main/java/jenkins/advancedqueue/PriorityConfigurationPlaceholderTaskHelper.java
@@ -1,11 +1,12 @@
 package jenkins.advancedqueue;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import hudson.Plugin;
 import hudson.model.Job;
 import hudson.model.Queue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
 import jenkins.advancedqueue.sorter.ItemInfo;
 import jenkins.advancedqueue.sorter.QueueItemCache;
 import jenkins.advancedqueue.sorter.strategy.MultiBucketStrategy;
@@ -20,8 +21,8 @@ class PriorityConfigurationPlaceholderTaskHelper {
 		return isPlaceholderTaskUsed() && task instanceof ExecutorStepExecution.PlaceholderTask;
 	}
 
-    @Nonnull
-    PriorityConfigurationCallback getPriority(@Nonnull ExecutorStepExecution.PlaceholderTask task, @Nonnull PriorityConfigurationCallback priorityCallback) {
+    @NonNull
+    PriorityConfigurationCallback getPriority(@NonNull ExecutorStepExecution.PlaceholderTask task, @NonNull PriorityConfigurationCallback priorityCallback) {
         Queue.Task ownerTask = task.getOwnerTask();
         if (ownerTask instanceof Job<?, ?>) {
             Job<?, ?> job = (Job<?, ?>) ownerTask;

--- a/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
@@ -23,6 +23,7 @@
  */
 package jenkins.advancedqueue;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.security.ACL;
@@ -142,6 +143,7 @@ public class PrioritySorterConfiguration extends GlobalConfiguration {
 		return FormValidation.ok();
 	}
 
+	@SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",justification="try with resources checks null")
 	private void updatePriorities(int prevNumberOfPriorities) {
 		// Shouldn't really by a permission problem when getting here but
 		// to be on the safe side

--- a/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
@@ -46,8 +46,6 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 

--- a/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/FolderPropertyLoader.java
+++ b/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/FolderPropertyLoader.java
@@ -32,8 +32,7 @@ import hudson.model.TopLevelItem;
 import hudson.util.DescribableList;
 import jenkins.advancedqueue.DecisionLogger;
 
-import com.cloudbees.hudson.plugins.folder.Folder;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
  * @author Magnus Sandberg

--- a/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/ViewBasedJobInclusionStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/ViewBasedJobInclusionStrategy.java
@@ -134,7 +134,7 @@ public class ViewBasedJobInclusionStrategy extends JobInclusionStrategy {
 		final Jenkins jenkins = Jenkins.get();
 		View view = jenkins.getView(nestedViewNames[0]);
 		if(null == view) {
-			LOGGER.severe("Configured View does not exist '" + viewName + "' using primary view");
+			LOGGER.log(Level.SEVERE, "Configured View does not exist ''{0}'' using primary view", viewName);
 			return jenkins.getPrimaryView();
 		}
 		for(int i = 1; i < nestedViewNames.length; i++) {
@@ -144,7 +144,7 @@ public class ViewBasedJobInclusionStrategy extends JobInclusionStrategy {
                         }
 			view = ((ViewGroup) view).getView(nestedViewNames[i]);
 			if(null == view) {
-				LOGGER.severe("Configured View does not exist '" + viewName + "' using primary view");
+				LOGGER.log(Level.SEVERE, "Configured View does not exist ''{0}'' using primary view", viewName);
 				return jenkins.getPrimaryView();
 			}
 		}

--- a/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/ViewBasedJobInclusionStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/ViewBasedJobInclusionStrategy.java
@@ -113,7 +113,11 @@ public class ViewBasedJobInclusionStrategy extends JobInclusionStrategy {
 		this.viewName = viewName;
 		this.useJobFilter = (jobFilter != null);
 		if (this.useJobFilter) {
-			this.jobPattern = jobFilter.jobPattern;
+			if (jobFilter != null) {
+				this.jobPattern = jobFilter.jobPattern;
+			} else {
+				LOGGER.log(Level.SEVERE, "Ignoring null job filter for view ''{0}''", viewName);
+			}
 		}
 	}
 

--- a/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/ViewBasedJobInclusionStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/jobinclusion/strategy/ViewBasedJobInclusionStrategy.java
@@ -32,6 +32,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
 import java.util.Collection;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -137,6 +138,10 @@ public class ViewBasedJobInclusionStrategy extends JobInclusionStrategy {
 			return jenkins.getPrimaryView();
 		}
 		for(int i = 1; i < nestedViewNames.length; i++) {
+			if (!(view instanceof ViewGroup)) {
+				LOGGER.log(Level.SEVERE, "View is not a ViewGroup ''{0}'', using primary view", viewName);
+				return jenkins.getPrimaryView();
+                        }
 			view = ((ViewGroup) view).getView(nestedViewNames[i]);
 			if(null == view) {
 				LOGGER.severe("Configured View does not exist '" + viewName + "' using primary view");

--- a/src/main/java/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestriction.java
+++ b/src/main/java/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestriction.java
@@ -23,6 +23,8 @@
  */
 package jenkins.advancedqueue.jobrestrictions;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.logging.Logger;
 
 import hudson.Extension;
@@ -48,6 +50,8 @@ import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.JobRestri
  * @author Magnus Sandberg
  * @since 3.3
  */
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID",
+                    justification="Common usage in Jenkins to not include SE_NO_SERIALVERSIONID")
 public class PrioritySorterRestriction extends JobRestriction {
 	
 	private final static Logger LOGGER = Logger.getLogger(PrioritySorterRestriction.class.getName());

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/BuildParameterStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/BuildParameterStrategy.java
@@ -23,14 +23,15 @@
  */
 package jenkins.advancedqueue.priority.strategy;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import hudson.Extension;
 import hudson.model.ParametersAction;
 import hudson.model.Queue;
 import hudson.model.StringParameterValue;
 
 import java.util.List;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 
 import jenkins.advancedqueue.Messages;
 import jenkins.advancedqueue.PrioritySorterConfiguration;
@@ -63,7 +64,7 @@ public class BuildParameterStrategy extends AbstractDynamicPriorityStrategy {
 	}
 
 	@CheckForNull
-	private Integer getPriorityInternal(@Nonnull Queue.Item item) {
+	private Integer getPriorityInternal(@NonNull Queue.Item item) {
 		List<ParametersAction> actions = item.getActions(ParametersAction.class);
 		for (ParametersAction action : actions) {
 			StringParameterValue parameterValue = (StringParameterValue) action.getParameter(parameterName);
@@ -88,13 +89,13 @@ public class BuildParameterStrategy extends AbstractDynamicPriorityStrategy {
 	 * @param item Queue item
 	 * @return Priority if it can be determined. Default priority otherwise
 	 */
-	public int getPriority(@Nonnull Queue.Item item) {
+	public int getPriority(@NonNull Queue.Item item) {
 		final Integer p = getPriorityInternal(item);
 		return p != null ? p : PrioritySorterConfiguration.get().getStrategy().getDefaultPriority();
 	}
 
 	@Override
-	public boolean isApplicable(@Nonnull Queue.Item item) {
+	public boolean isApplicable(@NonNull Queue.Item item) {
 		return getPriorityInternal(item) != null;
 	}
 }

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/JobPropertyStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/JobPropertyStrategy.java
@@ -23,11 +23,12 @@
  */
 package jenkins.advancedqueue.priority.strategy;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Queue.Item;
-import javax.annotation.CheckForNull;
 
 import jenkins.advancedqueue.Messages;
 import jenkins.advancedqueue.PrioritySorterConfiguration;

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/PriorityJobProperty.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/PriorityJobProperty.java
@@ -23,6 +23,7 @@
  */
 package jenkins.advancedqueue.priority.strategy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor.FormException;
@@ -83,7 +84,7 @@ public class PriorityJobProperty extends JobProperty<Job<?, ?>> {
 
 	@Extension
 	public static final class DescriptorImpl extends JobPropertyDescriptor {
-		
+		@SuppressFBWarnings(value="SIC_INNER_SHOULD_BE_STATIC_ANON", justification="Commont pattern in Jenkins")
 		private PriorityConfigurationCallback dummyCallback = new PriorityConfigurationCallback() {
 			
 			public PriorityConfigurationCallback setPrioritySelection(int priority, int jobGroupId, PriorityStrategy reason) {

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/PriorityJobProperty.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/PriorityJobProperty.java
@@ -87,18 +87,22 @@ public class PriorityJobProperty extends JobProperty<Job<?, ?>> {
 		@SuppressFBWarnings(value="SIC_INNER_SHOULD_BE_STATIC_ANON", justification="Commont pattern in Jenkins")
 		private PriorityConfigurationCallback dummyCallback = new PriorityConfigurationCallback() {
 			
+                        @Override
 			public PriorityConfigurationCallback setPrioritySelection(int priority, int jobGroupId, PriorityStrategy reason) {
 				return this;
 			}
 			
+                        @Override
 			public PriorityConfigurationCallback setPrioritySelection(int priority) {
 				return this;
 			}
 			
+                        @Override
 			public PriorityConfigurationCallback addDecisionLog(int indent, String log) {
 				return this;
 			}
 
+                        @Override
 			public PriorityConfigurationCallback setPrioritySelection(int priority, long sortAsInQueueSince,
 					int jobGroupId, PriorityStrategy reason) {
 				return this;

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/UpstreamCauseStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/UpstreamCauseStrategy.java
@@ -23,19 +23,19 @@
  */
 package jenkins.advancedqueue.priority.strategy;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import hudson.Extension;
 import hudson.model.Cause;
 import hudson.model.Cause.UpstreamCause;
 import hudson.model.Queue;
 
 import java.util.List;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 
 import jenkins.advancedqueue.Messages;
 import jenkins.advancedqueue.PrioritySorterConfiguration;
 import jenkins.advancedqueue.sorter.ItemInfo;
-import jenkins.advancedqueue.sorter.QueueItemCache;
 import jenkins.advancedqueue.sorter.StartedJobItemCache;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -58,7 +58,7 @@ public class UpstreamCauseStrategy extends AbstractDynamicPriorityStrategy {
 	}
 
 	@CheckForNull
-	private UpstreamCause getUpstreamCause(@Nonnull Queue.Item item) {
+	private UpstreamCause getUpstreamCause(@NonNull Queue.Item item) {
 		List<Cause> causes = item.getCauses();
 		for (Cause cause : causes) {
 			if (cause.getClass() == UpstreamCause.class) {

--- a/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorter.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorter.java
@@ -114,23 +114,6 @@ public class AdvancedQueueSorter extends QueueSorter {
 		}
 	}
 
-	/**
-	 * Returned the calculated, cached, weight or calculates the weight if missing. Should only be
-	 * called when the value should already be there, if the item is new {@link #onNewItem(Item)} is
-	 * the method to call.
-	 *
-	 * @param item the item to get the weight for
-	 * @return the calculated weight
-	 */
-	private float getCalculatedWeight(BuildableItem item) {
-		try {
-			return QueueItemCache.get().getItem(item.getId()).getWeight();
-		} catch (NullPointerException e) {
-			onNewItem(item);
-			return QueueItemCache.get().getItem(item.getId()).getWeight();
-		}
-	}
-
 	public void onNewItem(@Nonnull Item item) {
 		final SorterStrategy prioritySorterStrategy = PrioritySorterConfiguration.get().getStrategy();
 		ItemInfo itemInfo = new ItemInfo(item);

--- a/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorter.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorter.java
@@ -23,6 +23,8 @@
  */
 package jenkins.advancedqueue.sorter;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import hudson.Extension;
 import hudson.model.Queue;
 import hudson.model.Queue.BuildableItem;
@@ -35,7 +37,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
 
 import jenkins.advancedqueue.PriorityConfiguration;
 import jenkins.advancedqueue.PrioritySorterConfiguration;
@@ -112,7 +113,7 @@ public class AdvancedQueueSorter extends QueueSorter {
 		}
 	}
 
-	public void onNewItem(@Nonnull Item item) {
+	public void onNewItem(@NonNull Item item) {
 		final SorterStrategy prioritySorterStrategy = PrioritySorterConfiguration.get().getStrategy();
 		ItemInfo itemInfo = new ItemInfo(item);
 		PriorityConfiguration.get().getPriority(item, itemInfo);
@@ -121,7 +122,7 @@ public class AdvancedQueueSorter extends QueueSorter {
 		logNewItem(itemInfo);
 	}
 
-	public void onLeft(@Nonnull LeftItem li) {
+	public void onLeft(@NonNull LeftItem li) {
 		ItemInfo itemInfo = QueueItemCache.get().removeItem(li.getId());
                 if (itemInfo == null) {
                     LOGGER.log(Level.WARNING, "Received the onLeft() notification for the item from outside the QueueItemCache: {0}. " +

--- a/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorter.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorter.java
@@ -74,17 +74,15 @@ public class AdvancedQueueSorter extends QueueSorter {
 	@Override
 	public void sortBuildableItems(List<BuildableItem> items) {
 
-		Collections.sort(items, new Comparator<BuildableItem>() {
-			public int compare(BuildableItem o1, BuildableItem o2) {
-				ItemInfo item1 = QueueItemCache.get().getItem(o1.getId());
-				ItemInfo item2 = QueueItemCache.get().getItem(o2.getId());
-				if(item1 == null || item2 == null) {
-					LOGGER.warning("Requested to sort unknown items, sorting on queue-time only.");
-					return Long.compare(o1.getInQueueSince(), o2.getInQueueSince());
-				}
-				return item1.compareTo(item2);
-			}
-		});
+		Collections.sort(items, (BuildableItem o1, BuildableItem o2) -> {
+                    ItemInfo item1 = QueueItemCache.get().getItem(o1.getId());
+                    ItemInfo item2 = QueueItemCache.get().getItem(o2.getId());
+                    if(item1 == null || item2 == null) {
+                        LOGGER.warning("Requested to sort unknown items, sorting on queue-time only.");
+                        return Long.compare(o1.getInQueueSince(), o2.getInQueueSince());
+                    }
+                    return item1.compareTo(item2);
+                });
 		//
 		if (items.size() > 0 && LOGGER.isLoggable(Level.FINE)) {
 			float minWeight = QueueItemCache.get().getItem(items.get(0).getId()).getWeight();

--- a/src/main/java/jenkins/advancedqueue/sorter/QueueItemCache.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/QueueItemCache.java
@@ -23,6 +23,8 @@
  */
 package jenkins.advancedqueue.sorter;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
 import hudson.model.Queue.BlockedItem;
 import hudson.model.Queue.BuildableItem;
 
@@ -32,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
 
 /**
  * Keeps track of the Queue.Items seen by the Sorter. Uses a WeakHash to store the entries that have

--- a/src/main/java/jenkins/advancedqueue/sorter/SorterStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/SorterStrategy.java
@@ -23,6 +23,9 @@
  */
 package jenkins.advancedqueue.sorter;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
@@ -31,8 +34,6 @@ import hudson.model.Queue.LeftItem;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 
 import jenkins.model.Jenkins;
 
@@ -55,7 +56,7 @@ public abstract class SorterStrategy implements ExtensionPoint, Describable<Sort
 	 *            the weight before returning
 	 * @return the {@link SorterStrategyCallback} provided to the call must be returned
 	 */
-	public abstract SorterStrategyCallback onNewItem(@Nonnull Queue.Item item, SorterStrategyCallback weightCallback);
+	public abstract SorterStrategyCallback onNewItem(@NonNull Queue.Item item, SorterStrategyCallback weightCallback);
 
 	/**
 	 * Called when a {@link hudson.model.Item} leaves the queue and it is started.
@@ -63,13 +64,13 @@ public abstract class SorterStrategy implements ExtensionPoint, Describable<Sort
 	 * @param item the {@link hudson.model.Queue.LeftItem}
 	 * @param weight the weight assigned when the item entered the queue
 	 */
-	public void onStartedItem(@Nonnull LeftItem item, float weight) {
+	public void onStartedItem(@NonNull LeftItem item, float weight) {
 	}
 
 	/**
 	 * Called when a {@link hudson.model.Item} leaves the queue and it is canceled.
 	 */
-	public void onCanceledItem(@Nonnull LeftItem item) {
+	public void onCanceledItem(@NonNull LeftItem item) {
 	};
 
 	/**

--- a/src/main/java/jenkins/advancedqueue/sorter/StartedJobItemCache.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/StartedJobItemCache.java
@@ -23,11 +23,11 @@
  */
 package jenkins.advancedqueue.sorter;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.concurrent.TimeUnit;
-
-import javax.annotation.CheckForNull;
 
 import com.google.common.base.Objects;
 import com.google.common.cache.Cache;

--- a/src/main/java/jenkins/advancedqueue/sorter/strategy/MultiBucketStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/strategy/MultiBucketStrategy.java
@@ -23,10 +23,11 @@
  */
 package jenkins.advancedqueue.sorter.strategy;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
 import hudson.util.ListBoxModel;
 
 import java.io.IOException;
-import javax.annotation.CheckForNull;
 
 import javax.servlet.ServletException;
 

--- a/src/test/java/jenkins/advancedqueue/test/UpstreamTest.java
+++ b/src/test/java/jenkins/advancedqueue/test/UpstreamTest.java
@@ -1,5 +1,7 @@
 package jenkins.advancedqueue.test;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Collections;
@@ -13,7 +15,6 @@ import org.jvnet.hudson.test.recipes.LocalData;
 import hudson.model.Cause;
 import hudson.model.Cause.UpstreamCause;
 import hudson.model.Cause.UserIdCause;
-import javax.annotation.CheckForNull;
 import jenkins.advancedqueue.testutil.ExpectedItem;
 import jenkins.advancedqueue.testutil.JobHelper;
 import jenkins.advancedqueue.testutil.TestRunListener;


### PR DESCRIPTION
## Add deeper spotbugs checks

* Remove uncalled private method
* Increase spotbugs effort to Max
* Set spotbugs threshold to 'Low'
* Remove unused imports
* Replace JSR-305 annotations with spotbugs
* Use lambda expressions to resolve spotbugs warning
* Remove unused imports
* Use lambda expressions to resolve spotbugs warning
* Suppress spotbugs warning from try with resources
* Suppress spotbugs warning for inner class
* Add Override annotations
* Suppress spotbugs warning for serialVersionID
* Return primary view if view is not correct type
* Use parameters for logger rather than concatenation
* Guard against NPE in constructor
* Use spotbugs annotations, not JSR-305
* Remove unused import
