### PR TITLE
Enable pmd copy/paste detector report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <gitHubRepo>jenkinsci/priority-sorter-plugin</gitHubRepo>
         <jenkins.version>2.235.4</jenkins.version>
         <java.level>8</java.level>
+        <pmdVersion>6.40.0</pmdVersion>
     </properties>
     <artifactId>PrioritySorter</artifactId>
 	<version>${revision}${changelist}</version>
@@ -57,18 +58,42 @@
 	</dependencyManagement>
 
 	<build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>2.8.1</version>
-                <configuration>
-                    <generateBackupPoms>false</generateBackupPoms>
-                    <allowSnapshots>false</allowSnapshots>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+            <pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <version>3.15.0</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>net.sourceforge.pmd</groupId>
+                                <artifactId>pmd-core</artifactId>
+                                <version>${pmdVersion}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>net.sourceforge.pmd</groupId>
+                                <artifactId>pmd-java</artifactId>
+                                <version>${pmdVersion}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>3.15.0</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>cpd-check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
## Enable pmd copy/paste detector report

Also removes the version plugin configuration since the default configuration of the version plugin is sufficient for this plugin.
