### PR TITLE
Use https:// instead of git:// protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
 	</pluginRepositories>
 
 	<scm>
-		<connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+		<developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
 		<url>https://github.com/${gitHubRepo}</url>
 		<tag>${scmTag}</tag>
 	</scm>


### PR DESCRIPTION
## Use https:// instead of git:// protocol

GitHub is deprecating git:// protocol
