### PR TITLE
Check GitHub actions versions weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     target-branch: master
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly


### PR DESCRIPTION
## Check GitHub Actions for updates once a week

Versions of GitHub Actions are another dependency to be maintained.
