### PR TITLE
Add 'Report an issue' link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,7 @@ To get logging on when the *Queue Sorter* is active, use:
 
 * For recent versions, see [GitHub Releases](https://github.com/jenkinsci/priority-sorter-plugin/releases)
 * For versions 3.6 and older, see the [changelog archive](./docs/CHANGELOG.old.md)
+
+## Report an Issue
+
+Please report issues and enhancements through the [Jenkins issue tracker](https://www.jenkins.io/participate/report-issue/redirect/#15771).


### PR DESCRIPTION
## Add 'Report an Issue' link to documentation

Use the jenkins.io redirect that provides bug, improvement, and security issue reporting links.
