### PR TITLE
Require Jenkins 2.277.1 or later

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <revision>4.0.2</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/priority-sorter-plugin</gitHubRepo>
-        <jenkins.version>2.235.4</jenkins.version>
+        <jenkins.version>2.277.1</jenkins.version>
         <java.level>8</java.level>
         <pmdVersion>6.40.0</pmdVersion>
         <spotbugs.effort>Max</spotbugs.effort>
@@ -51,8 +51,8 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.235.x</artifactId>
-				<version>918.vae501d2cdc99</version>
+				<artifactId>bom-2.277.x</artifactId>
+				<version>984.vb5eaac999a7e</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>


### PR DESCRIPTION
## Require Jenkins 2.277.1 or later 

https://stats.jenkins.io/pluginversions/PrioritySorter.html shows that 88% of installations of priority sorter plugin 4.0.0 are on Jenkins 2.277.1 or later.  Users that are likely to adopt newer versions of the plugin are also likely to adopt newer versions of Jenkins.

The preceding version, 3.6.0, has only 8% of its installations on 2.277.1 or newer.  Since 3.6.0 has a tables to divs issue, it is not surprising that users are not updating to the newest Jenkins version until they update to the newest version of the plugin.
