### PR TITLE
Remove divBasedFormLayout jelly conditionals

### DIFF
--- a/src/main/resources/jenkins/advancedqueue/PriorityConfiguration/index.jelly
+++ b/src/main/resources/jenkins/advancedqueue/PriorityConfiguration/index.jelly
@@ -1,21 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:local="local">
-	<d:taglib uri="local">
-		<d:tag name="blockWrapper">
-			<j:choose>
-				<j:when test="${divBasedFormLayout}">
-					<div>
-						<d:invokeBody/>
-					</div>
-				</j:when>
-				<j:otherwise>
-					<table style="width:75%">
-						<d:invokeBody/>
-					</table>
-				</j:otherwise>
-			</j:choose>
-		</d:tag>
-	</d:taglib>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
 	<l:layout norefresh="true" title="${%Job Priorities}">
 	 	<l:side-panel>
             <l:tasks>
@@ -32,7 +16,7 @@
 				<f:form method="post" name="priorityConfigSubmit" action="priorityConfigSubmit">
 					<f:entry>
 						<f:repeatable var="jobGroup" items="${it.jobGroups}" header="Job group">
-							<local:blockWrapper>
+							<div>
 							   <f:entry title="${%Description}">
 										<f:textarea name="description" value="${jobGroup.description}"/>
 								</f:entry>
@@ -58,7 +42,7 @@
 								<f:optionalBlock name="usePriorityStrategies" checked="${jobGroup.usePriorityStrategies}" title="${%Use additional rules when assigning a priority to a job}">
 									<f:entry>
 										<f:repeatable var="holder" items="${jobGroup.priorityStrategies}" header="${%Priority Strategy}">
-											<local:blockWrapper>
+											<div>
 												<j:if test="${holder == null}">
 													<f:entry>
 														<f:dropdownDescriptorSelector descriptors="${it.getPriorityStrategyDescriptors()}" title="${%Select Strategy}"/>
@@ -77,7 +61,7 @@
 														<f:repeatableDeleteButton />
 													</div>
 												</f:entry>
-											</local:blockWrapper>
+											</div>
 										</f:repeatable>
 									</f:entry>
 								</f:optionalBlock>
@@ -86,7 +70,7 @@
 										<f:repeatableDeleteButton />
 									</div>
 								</f:entry>
-							</local:blockWrapper>
+							</div>
 						</f:repeatable>
 						<br/>
 						<br/>


### PR DESCRIPTION
## Remove divBasedFormLayout jelly conditionals

Do not need the conditional for div based layout.  The plugin only supports versions that provide div based layout.
