### PR TITLE
Test JDK 8 and JDK 11 in ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,8 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(failFast: false)
+buildPlugin(failFast: false,
+            configurations: [
+                [platform: 'linux', jdk: '11'],
+                [platform: 'windows', jdk: '8'],
+            ])


### PR DESCRIPTION
## Test JDK 8 and JDK 11 in CI

JDK 8 support will eventually be dropped from Jenkins.  Test both JDK 8 and JDK 11 until this plugin requires Java 11 or newer.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
