### PR TITLE
Bugfix/adapt extended upstream cause and search short project name only

### DIFF
--- a/src/main/java/jenkins/advancedqueue/priority/strategy/UpstreamCauseStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/UpstreamCauseStrategy.java
@@ -61,7 +61,7 @@ public class UpstreamCauseStrategy extends AbstractDynamicPriorityStrategy {
 	private UpstreamCause getUpstreamCause(@NonNull Queue.Item item) {
 		List<Cause> causes = item.getCauses();
 		for (Cause cause : causes) {
-			if (cause.getClass() == UpstreamCause.class) {
+			if (cause.getClass() == UpstreamCause.class || UpstreamCause.class.isAssignableFrom(cause.getClass())) {
 				return (UpstreamCause) cause;
 			}
 		}

--- a/src/main/java/jenkins/advancedqueue/priority/strategy/UpstreamCauseStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/UpstreamCauseStrategy.java
@@ -76,6 +76,8 @@ public class UpstreamCauseStrategy extends AbstractDynamicPriorityStrategy {
                 }
                 
 		String upstreamProject = upstreamCause.getUpstreamProject();
+		// Only use short job name to find in cache
+		upstreamProject = upstreamProject.substring(upstreamProject.lastIndexOf('/') + 1);
 		int upstreamBuildId = upstreamCause.getUpstreamBuild();
 		ItemInfo upstreamItem = StartedJobItemCache.get().getStartedItem(upstreamProject, upstreamBuildId);
 		// Upstream Item being null should be very very rare


### PR DESCRIPTION
1. Get UpstreamCause should work with all classes which are extended from UpstreamCause because some plugins will use extended class from UpstreamCause in Jenkins such as Pipeline job.
2. We should use short project name (without parent folder) to search in cached priority because we store short name only.