### PR TITLE
Require Jenkins 2.332.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <revision>4.1.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/priority-sorter-plugin</gitHubRepo>
-        <jenkins.version>2.319.3</jenkins.version>
+        <jenkins.version>2.332.4</jenkins.version>
         <pmdVersion>6.48.0</pmdVersion>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
@@ -49,7 +49,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.319.x</artifactId>
+				<artifactId>bom-2.332.x</artifactId>
 				<version>1577.v63609d9cb_5dc</version>
 				<scope>import</scope>
 				<type>pom</type>


### PR DESCRIPTION
## Require Jenkins 2.332.4

Jenkins 2.332.4 is a recommended baseline version and is the oldest LTS that is not affected by a security advisory.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
