### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(failFast: false,
             configurations: [
-                [platform: 'linux',   jdk: '17', jenkins: '2.342'],
-                [platform: 'linux',   jdk: '11'],
-                [platform: 'windows', jdk: '8' ],
+                [platform: 'linux',   jdk: '17', jenkins: '2.371'  ],
+                [platform: 'linux',   jdk: '11', jenkins: '2.361.1'],
+                [platform: 'windows', jdk: '8'                     ],
             ])

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>nested-view</artifactId>
-			<version>1.24</version>
+			<version>1.26</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,12 +122,6 @@
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>matrix-project</artifactId>
 			<optional>true</optional>
-			<exclusions>
-				<exclusion>
-					<groupId>javax.annotation</groupId>
-					<artifactId>javax.annotation-api</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <revision>4.1.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/priority-sorter-plugin</gitHubRepo>
-        <jenkins.version>2.332.4</jenkins.version>
+        <jenkins.version>2.346.3</jenkins.version>
         <pmdVersion>6.50.0</pmdVersion>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
@@ -49,7 +49,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.332.x</artifactId>
+				<artifactId>bom-2.346.x</artifactId>
 				<version>1607.va_c1576527071</version>
 				<scope>import</scope>
 				<type>pom</type>

--- a/src/main/java/jenkins/advancedqueue/RunExclusiveThrottler.java
+++ b/src/main/java/jenkins/advancedqueue/RunExclusiveThrottler.java
@@ -1,5 +1,7 @@
 package jenkins.advancedqueue;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import hudson.Extension;
 import hudson.model.Queue.Item;
 import hudson.model.Run;
@@ -18,7 +20,9 @@ import jenkins.advancedqueue.sorter.QueueItemCache;
 public class RunExclusiveThrottler {
 
 	static private List<String> exclusiveJobs = Collections.synchronizedList(new ArrayList<String>());
+        @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "Low risk")
 	static private int exclusiveJobGroupId = -1;
+        @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "Low risk")
 	static private String exclusiveJobName = "";
 
 	static PriorityConfigurationCallback dummyCallback = new PriorityConfigurationCallback() {


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

60% of installations of the most recent release of the plugin (now 9 months old) are running Jenkins 2.346.1 or newer based on the [install stats](https://stats.jenkins.io/pluginversions/PrioritySorter.html). Jenkins 2.346.3 is a good choice as the last LTS version before Jenkins core requires Java 11.

- Remove unused exclusion
- Require Jenkins 2.346.3 or newer
- Test with nested view plugin 1.26

Resolves a GitHub false positive warning about the nested view plugin 1.24 vulnerability.  Since the nested-view plugin dependency is only in test scope, vulnerabilities in that plugin do not affect this plugin.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
