### PR TITLE
JENKINS-69757 Improve priority sorter plugin automated test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
       <version>1.25</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <version>5.3.1</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -117,12 +117,12 @@
       <version>1.25</version>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-core</artifactId>
-          <version>5.3.1</version>
-          <scope>test</scope>
-      </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.3.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/test/java/jenkins/advancedqueue/test/MatrixTest.java
+++ b/src/test/java/jenkins/advancedqueue/test/MatrixTest.java
@@ -17,63 +17,65 @@ public class MatrixTest {
 
     private JobHelper jobHelper = new JobHelper(j);
 
-        @Test
-        @LocalData
-        public void simple_matrix_with_no_configuration() throws Exception {
-            TestRunListener.init(
-                    new ExpectedItem("Matrix 0", 1), new ExpectedItem("0A1=0A.", 1), new ExpectedItem("0A1=0A.", 1));
-            jobHelper.scheduleMatrixProjects(new Cause.UserIdCause()).go();
-            j.waitUntilNoActivity();
-            TestRunListener.assertStartedItems();
-        }
+    @Test
+    @LocalData
+    public void simple_matrix_with_no_configuration() throws Exception {
+        TestRunListener.init(
+                new ExpectedItem("Matrix 0", 1), new ExpectedItem("0A1=0A.", 1), new ExpectedItem("0A1=0A.", 1));
+        jobHelper.scheduleMatrixProjects(new Cause.UserIdCause()).go();
+        j.waitUntilNoActivity();
+        TestRunListener.assertStartedItems();
+    }
 
-        @Test
-        @LocalData
-        public void simple_two_matrix_with_no_configuration() throws Exception {
-            TestRunListener.init(
-                    new ExpectedItem("Matrix 0", 1), new ExpectedItem("Matrix 1", 1),
-                    new ExpectedItem("0A1=0A.", 1), new ExpectedItem("0A1=0A.", 1),
-                    new ExpectedItem("1A1=1A.", 1), new ExpectedItem("1A1=1A.", 1));
-            jobHelper.scheduleMatrixProjects(new Cause.UserIdCause(), new Cause.UserIdCause()).go();
-            j.waitUntilNoActivity();
-            TestRunListener.assertStartedItems();
-        }
+    @Test
+    @LocalData
+    public void simple_two_matrix_with_no_configuration() throws Exception {
+        TestRunListener.init(
+                new ExpectedItem("Matrix 0", 1), new ExpectedItem("Matrix 1", 1),
+                new ExpectedItem("0A1=0A.", 1), new ExpectedItem("0A1=0A.", 1),
+                new ExpectedItem("1A1=1A.", 1), new ExpectedItem("1A1=1A.", 1));
+        jobHelper
+                .scheduleMatrixProjects(new Cause.UserIdCause(), new Cause.UserIdCause())
+                .go();
+        j.waitUntilNoActivity();
+        TestRunListener.assertStartedItems();
+    }
 
-        @Test
-        @LocalData
-        public void matrix_and_jobs_with_no_configuration() throws Exception {
-            TestRunListener.init(
-                    new ExpectedItem("Matrix 0", 1),
-                    new ExpectedItem("Matrix 1", 5),
-                    new ExpectedItem("0A1=0A.", 1),
-                    new ExpectedItem("0A1=0A.", 1),
-                    new ExpectedItem("Job 0", 5),
-                    new ExpectedItem("1A1=1A.", 5),
-                    new ExpectedItem("1A1=1A.", 5));
-            jobHelper
-                    .scheduleProjects(new BuildCommand.CLICause())
-                    .scheduleMatrixProjects(new Cause.UserIdCause(), new BuildCommand.CLICause())
-                    .go();
-            j.waitUntilNoActivity();
-            TestRunListener.assertStartedItems();
-        }
+    @Test
+    @LocalData
+    public void matrix_and_jobs_with_no_configuration() throws Exception {
+        TestRunListener.init(
+                new ExpectedItem("Matrix 0", 1),
+                new ExpectedItem("Matrix 1", 5),
+                new ExpectedItem("0A1=0A.", 1),
+                new ExpectedItem("0A1=0A.", 1),
+                new ExpectedItem("Job 0", 5),
+                new ExpectedItem("1A1=1A.", 5),
+                new ExpectedItem("1A1=1A.", 5));
+        jobHelper
+                .scheduleProjects(new BuildCommand.CLICause())
+                .scheduleMatrixProjects(new Cause.UserIdCause(), new BuildCommand.CLICause())
+                .go();
+        j.waitUntilNoActivity();
+        TestRunListener.assertStartedItems();
+    }
 
-        @Test
-        @LocalData
-        public void matrix_and_jobs_with_no_configuration_reverse() throws Exception {
-            TestRunListener.init(
-                    new ExpectedItem("Matrix 0", 1),
-                    new ExpectedItem("Matrix 1", 5),
-                    new ExpectedItem("0A1=0A.", 1),
-                    new ExpectedItem("0A1=0A.", 1),
-                    new ExpectedItem("1A1=1A.", 5),
-                    new ExpectedItem("1A1=1A.", 5),
-                    new ExpectedItem("Job 0", 5));
-            jobHelper
-                    .scheduleMatrixProjects(new Cause.UserIdCause(), new BuildCommand.CLICause())
-                    .scheduleProjects(new BuildCommand.CLICause())
-                    .go();
-            j.waitUntilNoActivity();
-            TestRunListener.assertStartedItems();
-        }
+    @Test
+    @LocalData
+    public void matrix_and_jobs_with_no_configuration_reverse() throws Exception {
+        TestRunListener.init(
+                new ExpectedItem("Matrix 0", 1),
+                new ExpectedItem("Matrix 1", 5),
+                new ExpectedItem("0A1=0A.", 1),
+                new ExpectedItem("0A1=0A.", 1),
+                new ExpectedItem("1A1=1A.", 5),
+                new ExpectedItem("1A1=1A.", 5),
+                new ExpectedItem("Job 0", 5));
+        jobHelper
+                .scheduleMatrixProjects(new Cause.UserIdCause(), new BuildCommand.CLICause())
+                .scheduleProjects(new BuildCommand.CLICause())
+                .go();
+        j.waitUntilNoActivity();
+        TestRunListener.assertStartedItems();
+    }
 }

--- a/src/test/java/jenkins/advancedqueue/test/MatrixTest.java
+++ b/src/test/java/jenkins/advancedqueue/test/MatrixTest.java
@@ -1,7 +1,7 @@
 package jenkins.advancedqueue.test;
 
-import hudson.cli.BuildCommand.CLICause;
-import hudson.model.Cause.UserIdCause;
+import hudson.cli.BuildCommand;
+import hudson.model.Cause;
 import jenkins.advancedqueue.testutil.ExpectedItem;
 import jenkins.advancedqueue.testutil.JobHelper;
 import jenkins.advancedqueue.testutil.TestRunListener;
@@ -17,63 +17,63 @@ public class MatrixTest {
 
     private JobHelper jobHelper = new JobHelper(j);
 
-    @Test
-    @LocalData
-    public void simple_matrix_with_no_configuration() throws Exception {
-        TestRunListener.init(
-                new ExpectedItem("Matrix 0", 1), new ExpectedItem("0A1=0A.", 1), new ExpectedItem("0A1=0A.", 1));
-        jobHelper.scheduleMatrixProjects(new UserIdCause()).go();
-        j.waitUntilNoActivity();
-        TestRunListener.assertStartedItems();
-    }
+        @Test
+        @LocalData
+        public void simple_matrix_with_no_configuration() throws Exception {
+            TestRunListener.init(
+                    new ExpectedItem("Matrix 0", 1), new ExpectedItem("0A1=0A.", 1), new ExpectedItem("0A1=0A.", 1));
+            jobHelper.scheduleMatrixProjects(new Cause.UserIdCause()).go();
+            j.waitUntilNoActivity();
+            TestRunListener.assertStartedItems();
+        }
 
-    @Test
-    @LocalData
-    public void simple_two_matrix_with_no_configuration() throws Exception {
-        TestRunListener.init(
-                new ExpectedItem("Matrix 0", 1), new ExpectedItem("Matrix 1", 1),
-                new ExpectedItem("0A1=0A.", 1), new ExpectedItem("0A1=0A.", 1),
-                new ExpectedItem("1A1=1A.", 1), new ExpectedItem("1A1=1A.", 1));
-        jobHelper.scheduleMatrixProjects(new UserIdCause(), new UserIdCause()).go();
-        j.waitUntilNoActivity();
-        TestRunListener.assertStartedItems();
-    }
+        @Test
+        @LocalData
+        public void simple_two_matrix_with_no_configuration() throws Exception {
+            TestRunListener.init(
+                    new ExpectedItem("Matrix 0", 1), new ExpectedItem("Matrix 1", 1),
+                    new ExpectedItem("0A1=0A.", 1), new ExpectedItem("0A1=0A.", 1),
+                    new ExpectedItem("1A1=1A.", 1), new ExpectedItem("1A1=1A.", 1));
+            jobHelper.scheduleMatrixProjects(new Cause.UserIdCause(), new Cause.UserIdCause()).go();
+            j.waitUntilNoActivity();
+            TestRunListener.assertStartedItems();
+        }
 
-    @Test
-    @LocalData
-    public void matrix_and_jobs_with_no_configuration() throws Exception {
-        TestRunListener.init(
-                new ExpectedItem("Matrix 0", 1),
-                new ExpectedItem("Matrix 1", 5),
-                new ExpectedItem("0A1=0A.", 1),
-                new ExpectedItem("0A1=0A.", 1),
-                new ExpectedItem("Job 0", 5),
-                new ExpectedItem("1A1=1A.", 5),
-                new ExpectedItem("1A1=1A.", 5));
-        jobHelper
-                .scheduleProjects(new CLICause())
-                .scheduleMatrixProjects(new UserIdCause(), new CLICause())
-                .go();
-        j.waitUntilNoActivity();
-        TestRunListener.assertStartedItems();
-    }
+        @Test
+        @LocalData
+        public void matrix_and_jobs_with_no_configuration() throws Exception {
+            TestRunListener.init(
+                    new ExpectedItem("Matrix 0", 1),
+                    new ExpectedItem("Matrix 1", 5),
+                    new ExpectedItem("0A1=0A.", 1),
+                    new ExpectedItem("0A1=0A.", 1),
+                    new ExpectedItem("Job 0", 5),
+                    new ExpectedItem("1A1=1A.", 5),
+                    new ExpectedItem("1A1=1A.", 5));
+            jobHelper
+                    .scheduleProjects(new BuildCommand.CLICause())
+                    .scheduleMatrixProjects(new Cause.UserIdCause(), new BuildCommand.CLICause())
+                    .go();
+            j.waitUntilNoActivity();
+            TestRunListener.assertStartedItems();
+        }
 
-    @Test
-    @LocalData
-    public void matrix_and_jobs_with_no_configuration_reverse() throws Exception {
-        TestRunListener.init(
-                new ExpectedItem("Matrix 0", 1),
-                new ExpectedItem("Matrix 1", 5),
-                new ExpectedItem("0A1=0A.", 1),
-                new ExpectedItem("0A1=0A.", 1),
-                new ExpectedItem("1A1=1A.", 5),
-                new ExpectedItem("1A1=1A.", 5),
-                new ExpectedItem("Job 0", 5));
-        jobHelper
-                .scheduleMatrixProjects(new UserIdCause(), new CLICause())
-                .scheduleProjects(new CLICause())
-                .go();
-        j.waitUntilNoActivity();
-        TestRunListener.assertStartedItems();
-    }
+        @Test
+        @LocalData
+        public void matrix_and_jobs_with_no_configuration_reverse() throws Exception {
+            TestRunListener.init(
+                    new ExpectedItem("Matrix 0", 1),
+                    new ExpectedItem("Matrix 1", 5),
+                    new ExpectedItem("0A1=0A.", 1),
+                    new ExpectedItem("0A1=0A.", 1),
+                    new ExpectedItem("1A1=1A.", 5),
+                    new ExpectedItem("1A1=1A.", 5),
+                    new ExpectedItem("Job 0", 5));
+            jobHelper
+                    .scheduleMatrixProjects(new Cause.UserIdCause(), new BuildCommand.CLICause())
+                    .scheduleProjects(new BuildCommand.CLICause())
+                    .go();
+            j.waitUntilNoActivity();
+            TestRunListener.assertStartedItems();
+        }
 }

--- a/src/test/java/jenkins/advancedqueue/test/MatrixTest.java
+++ b/src/test/java/jenkins/advancedqueue/test/MatrixTest.java
@@ -1,7 +1,7 @@
 package jenkins.advancedqueue.test;
 
-import hudson.cli.BuildCommand;
-import hudson.model.Cause;
+import hudson.cli.BuildCommand.CLICause;
+import hudson.model.Cause.UserIdCause;
 import jenkins.advancedqueue.testutil.ExpectedItem;
 import jenkins.advancedqueue.testutil.JobHelper;
 import jenkins.advancedqueue.testutil.TestRunListener;
@@ -22,7 +22,7 @@ public class MatrixTest {
     public void simple_matrix_with_no_configuration() throws Exception {
         TestRunListener.init(
                 new ExpectedItem("Matrix 0", 1), new ExpectedItem("0A1=0A.", 1), new ExpectedItem("0A1=0A.", 1));
-        jobHelper.scheduleMatrixProjects(new Cause.UserIdCause()).go();
+        jobHelper.scheduleMatrixProjects(new UserIdCause()).go();
         j.waitUntilNoActivity();
         TestRunListener.assertStartedItems();
     }
@@ -34,9 +34,7 @@ public class MatrixTest {
                 new ExpectedItem("Matrix 0", 1), new ExpectedItem("Matrix 1", 1),
                 new ExpectedItem("0A1=0A.", 1), new ExpectedItem("0A1=0A.", 1),
                 new ExpectedItem("1A1=1A.", 1), new ExpectedItem("1A1=1A.", 1));
-        jobHelper
-                .scheduleMatrixProjects(new Cause.UserIdCause(), new Cause.UserIdCause())
-                .go();
+        jobHelper.scheduleMatrixProjects(new UserIdCause(), new UserIdCause()).go();
         j.waitUntilNoActivity();
         TestRunListener.assertStartedItems();
     }
@@ -53,8 +51,8 @@ public class MatrixTest {
                 new ExpectedItem("1A1=1A.", 5),
                 new ExpectedItem("1A1=1A.", 5));
         jobHelper
-                .scheduleProjects(new BuildCommand.CLICause())
-                .scheduleMatrixProjects(new Cause.UserIdCause(), new BuildCommand.CLICause())
+                .scheduleProjects(new CLICause())
+                .scheduleMatrixProjects(new UserIdCause(), new CLICause())
                 .go();
         j.waitUntilNoActivity();
         TestRunListener.assertStartedItems();
@@ -72,8 +70,8 @@ public class MatrixTest {
                 new ExpectedItem("1A1=1A.", 5),
                 new ExpectedItem("Job 0", 5));
         jobHelper
-                .scheduleMatrixProjects(new Cause.UserIdCause(), new BuildCommand.CLICause())
-                .scheduleProjects(new BuildCommand.CLICause())
+                .scheduleMatrixProjects(new UserIdCause(), new CLICause())
+                .scheduleProjects(new CLICause())
                 .go();
         j.waitUntilNoActivity();
         TestRunListener.assertStartedItems();

--- a/src/test/java/jenkins/advancedqueue/test/PrioritySorterConfigurationTest.java
+++ b/src/test/java/jenkins/advancedqueue/test/PrioritySorterConfigurationTest.java
@@ -1,24 +1,24 @@
 package jenkins.advancedqueue.test;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import hudson.util.ListBoxModel;
+import java.util.Arrays;
+import java.util.List;
 import jenkins.advancedqueue.PrioritySorterConfiguration;
 import jenkins.advancedqueue.sorter.SorterStrategy;
 import jenkins.advancedqueue.sorter.SorterStrategyDescriptor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import hudson.util.ListBoxModel;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.MockedStatic;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
 
 public class PrioritySorterConfigurationTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
+
     private PrioritySorterConfiguration prioritySorterConfiguration;
     private SorterStrategyDescriptor sorterStrategyDescriptor1, sorterStrategyDescriptor2;
 
@@ -36,7 +36,8 @@ public class PrioritySorterConfigurationTest {
         when(sorterStrategyDescriptor2.getDisplayName()).thenReturn("DisplayName2");
         when(sorterStrategyDescriptor2.getKey()).thenReturn("Key2");
 
-        List<SorterStrategyDescriptor> mockStrategies = Arrays.asList(sorterStrategyDescriptor1, sorterStrategyDescriptor2);
+        List<SorterStrategyDescriptor> mockStrategies =
+                Arrays.asList(sorterStrategyDescriptor1, sorterStrategyDescriptor2);
 
         try (MockedStatic<SorterStrategy> mocked = mockStatic(SorterStrategy.class)) {
             mocked.when(SorterStrategy::getAllSorterStrategies).thenReturn(mockStrategies);

--- a/src/test/java/jenkins/advancedqueue/test/PrioritySorterConfigurationTest.java
+++ b/src/test/java/jenkins/advancedqueue/test/PrioritySorterConfigurationTest.java
@@ -4,8 +4,12 @@ import jenkins.advancedqueue.PrioritySorterConfiguration;
 import jenkins.advancedqueue.sorter.SorterStrategy;
 import jenkins.advancedqueue.sorter.SorterStrategyDescriptor;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import hudson.util.ListBoxModel;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.MockedStatic;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -13,6 +17,8 @@ import static org.mockito.Mockito.*;
 import static org.junit.Assert.*;
 
 public class PrioritySorterConfigurationTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
     private PrioritySorterConfiguration prioritySorterConfiguration;
     private SorterStrategyDescriptor sorterStrategyDescriptor1, sorterStrategyDescriptor2;
 
@@ -31,14 +37,17 @@ public class PrioritySorterConfigurationTest {
         when(sorterStrategyDescriptor2.getKey()).thenReturn("Key2");
 
         List<SorterStrategyDescriptor> mockStrategies = Arrays.asList(sorterStrategyDescriptor1, sorterStrategyDescriptor2);
-        when(SorterStrategy.getAllSorterStrategies()).thenReturn(mockStrategies);
 
-        ListBoxModel result = prioritySorterConfiguration.doFillStrategyItems();
+        try (MockedStatic<SorterStrategy> mocked = mockStatic(SorterStrategy.class)) {
+            mocked.when(SorterStrategy::getAllSorterStrategies).thenReturn(mockStrategies);
 
-        assertEquals(2, result.size());
-        assertEquals("DisplayName1", result.get(0).name);
-        assertEquals("Key1", result.get(0).value);
-        assertEquals("DisplayName2", result.get(1).name);
-        assertEquals("Key2", result.get(1).value);
+            ListBoxModel result = prioritySorterConfiguration.doFillStrategyItems();
+
+            assertEquals(2, result.size());
+            assertEquals("DisplayName1", result.get(0).name);
+            assertEquals("Key1", result.get(0).value);
+            assertEquals("DisplayName2", result.get(1).name);
+            assertEquals("Key2", result.get(1).value);
+        }
     }
 }

--- a/src/test/java/jenkins/advancedqueue/test/PrioritySorterConfigurationTest.java
+++ b/src/test/java/jenkins/advancedqueue/test/PrioritySorterConfigurationTest.java
@@ -1,0 +1,44 @@
+package jenkins.advancedqueue.test;
+
+import jenkins.advancedqueue.PrioritySorterConfiguration;
+import jenkins.advancedqueue.sorter.SorterStrategy;
+import jenkins.advancedqueue.sorter.SorterStrategyDescriptor;
+import org.junit.Before;
+import org.junit.Test;
+import hudson.util.ListBoxModel;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+public class PrioritySorterConfigurationTest {
+    private PrioritySorterConfiguration prioritySorterConfiguration;
+    private SorterStrategyDescriptor sorterStrategyDescriptor1, sorterStrategyDescriptor2;
+
+    @Before
+    public void setUp() {
+        prioritySorterConfiguration = new PrioritySorterConfiguration();
+        sorterStrategyDescriptor1 = mock(SorterStrategyDescriptor.class);
+        sorterStrategyDescriptor2 = mock(SorterStrategyDescriptor.class);
+    }
+
+    @Test
+    public void testDoFillStrategyItems() {
+        when(sorterStrategyDescriptor1.getDisplayName()).thenReturn("DisplayName1");
+        when(sorterStrategyDescriptor1.getKey()).thenReturn("Key1");
+        when(sorterStrategyDescriptor2.getDisplayName()).thenReturn("DisplayName2");
+        when(sorterStrategyDescriptor2.getKey()).thenReturn("Key2");
+
+        List<SorterStrategyDescriptor> mockStrategies = Arrays.asList(sorterStrategyDescriptor1, sorterStrategyDescriptor2);
+        when(SorterStrategy.getAllSorterStrategies()).thenReturn(mockStrategies);
+
+        ListBoxModel result = prioritySorterConfiguration.doFillStrategyItems();
+
+        assertEquals(2, result.size());
+        assertEquals("DisplayName1", result.get(0).name);
+        assertEquals("Key1", result.get(0).value);
+        assertEquals("DisplayName2", result.get(1).name);
+        assertEquals("Key2", result.get(1).value);
+    }
+}


### PR DESCRIPTION
[JENKINS-69757](https://issues.jenkins.io/browse/JENKINS-69757)
This pull request introduces new tests for the PrioritySorterConfiguration class, specifically targeting the doFillStrategyItems method.

The doFillStrategyItems method is responsible for populating a ListBoxModel with the display names and keys of all sorter strategies. The test, testDoFillStrategyItems, ensures that this List BoxModel is correctly populated.
![7771684196549_ pic](https://github.com/jenkinsci/priority-sorter-plugin/assets/72024042/e9c15719-d0d4-4d46-b25d-232f9326c9c2)

![7791684203855_ pic](https://github.com/jenkinsci/priority-sorter-plugin/assets/72024042/b31a87a2-946d-4f79-a6ea-116abf7a98ae)

The test leverages Mockito to mock the SorterStrategyDescriptor instances and their respective methods, getDisplayName and getKey. It verifies that the ListBoxModel returned by doFillStrategyItems contains the correct number of items and that each item's name and value match the expected values.
