### PR TITLE
Require Jenkins 2.387.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,6 @@ buildPlugin(
   // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
   configurations: [
     [platform: 'linux',   jdk: '11'], // Linux first for coverage report on ci.jenkins.io
-    [platform: 'windows', jdk: '17', jenkins: '2.389'],
+    [platform: 'windows', jdk: '17', jenkins: '2.407'],
   ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <revision>4.1.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/priority-sorter-plugin</gitHubRepo>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
     <pmdVersion>6.55.0</pmdVersion>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -56,7 +56,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
+        <artifactId>bom-2.387.x</artifactId>
         <version>2102.v854b_fec19c92</version>
         <type>pom</type>
         <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <version>2133.v2e6c00fe4d61</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.387.3 or newer

- Test Jenkins 2.407 on ci.jenkins.io
- Require Jenkins 2.387.3 or newer
- Use plugin BOM 2133.v2e6c00fe4d61

### Testing done

Verified plugin tests run successfully on Linux Java 11 with Jenkins 2.387.3 as minimum Jenkins version.  Will rely on ci.jenkins.io to verify Windows with Java 17 and Jenkins 2.407.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
