### PR TITLE
Bump plugin pom from 4.66 to 4.67

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.66</version>
+    <version>4.67</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Bump plugin pom from 4.66 to 4.67

https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.67 provides more details of the changes, including:

* Fix hamcrest versioning - @timja https://redirect.github.com/jenkinsci/plugin-pom/issues/785
* Update HtmlUnit package for jacoco - @timja https://redirect.github.com/jenkinsci/plugin-pom/issues/778

### Testing done

Compiles and tests successfully on Linux with Java 11.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
