### PR TITLE
Use spotbugs 4.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,9 @@
     <gitHubRepo>jenkinsci/priority-sorter-plugin</gitHubRepo>
     <jenkins.version>2.401.3</jenkins.version>
     <pmdVersion>6.55.0</pmdVersion>
+    <!-- TODO: Remove when plugin pom is using this version or newer -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
@@ -61,6 +61,7 @@ public class PrioritySorterConfiguration extends GlobalConfiguration {
      * @deprecated used in 2.x - replaces with XXX
      */
     @Deprecated
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Allow deserialization of old definitions")
     private boolean allowPriorityOnJobs;
 
     private boolean onlyAdminsMayEditPriorityConfiguration = false;

--- a/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
@@ -67,7 +67,10 @@ public class PrioritySorterConfiguration extends GlobalConfiguration {
 
     private SorterStrategy strategy;
 
-    public PrioritySorterConfiguration() {}
+    public PrioritySorterConfiguration() {
+        /* Initalize strategy to prevent spotbugs uninitialized field warning */
+        strategy = DEFAULT_STRATEGY;
+    }
 
     public static void init() {
         PrioritySorterConfiguration prioritySorterConfiguration = PrioritySorterConfiguration.get();


### PR DESCRIPTION
## Use spotbugs 4.8.2

Suppress an unread field warning to retain compatibility.

Initialize strategy to avoid spotbugs warning

No evidence of any detected bug, but initializing a field in the constructor seems reasonable, especially since it is using the value that is assigned in the init() method.

### Testing done

Automated tests pass and the code is covered by the automated tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
