### PR TITLE
Replace deprecated javax annotation with spotbugs annotation

### DIFF
--- a/src/test/java/org/kohsuke/stapler/MockStaplerRequest.java
+++ b/src/test/java/org/kohsuke/stapler/MockStaplerRequest.java
@@ -25,11 +25,11 @@ package org.kohsuke.stapler;
 
 import static org.mockito.Mockito.mock;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -43,7 +43,7 @@ public class MockStaplerRequest {
         final Map<String, Object> getters = new HashMap<>();
         private Stapler stapler;
 
-        public MockStaplerRequestBuilder(@Nonnull JenkinsRule r, String url) {
+        public MockStaplerRequestBuilder(@NonNull JenkinsRule r, String url) {
             this.r = r;
             this.tokens = new TokenList(url);
         }


### PR DESCRIPTION
The javax.annotation.Nonnull has been deprecated for a long time and is steadily being removed from Jenkins.
