### PR TITLE
Suppress future spotbugs warning for equals test

### DIFF
--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -13,6 +13,12 @@
     <Class name="jenkins.advancedqueue.RunExclusiveThrottler$RunExclusiveRunListener"/>
     <Method name="onStarted"/>
   </Match>
+  <Match>
+    <!-- valid use of equals for compareTo -->
+    <Bug pattern="FE_FLOATING_POINT_EQUALITY"/>
+    <Class name="jenkins.advancedqueue.sorter.ItemInfo"/>
+    <Method name="compareTo"/>
+  </Match>
 
   <!--
     Here lies technical debt. Exclusions in this section have not yet


### PR DESCRIPTION
## Suppress future spotbugs warning for equals test

Floating point equality test in this case is reasonable since it is being used in a compareTo method.

### Testing done

Confirmed the suppressed warning is no longer reported.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
