### PR TITLE
[JENKINS-73910] Extract inline event handlers to separate JavaScript files

### DIFF
--- a/src/main/resources/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestriction/config.jelly
+++ b/src/main/resources/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestriction/config.jelly
@@ -3,8 +3,8 @@
     <st:adjunct includes="jenkins.advancedqueue.jobrestrictions.PrioritySorterRestriction.update-list-box"/>
     <f:entry title="${%From_Priority}" field="fromPriority">
         <f:select 
-        	id="fromPriority" 
-        	default="${descriptor.defaultPriority}"
+            id="fromPriority"
+            default="${descriptor.defaultPriority}"
             data-descriptor-url="${descriptor.descriptorUrl}"/>
     </f:entry> 
     <f:entry title="${%To_Priority}" field="toPriority">

--- a/src/main/resources/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestriction/config.jelly
+++ b/src/main/resources/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestriction/config.jelly
@@ -1,10 +1,11 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:sl="/hudson/plugins/sidebar_link">
+    <st:adjunct includes="jenkins.advancedqueue.jobrestrictions.PrioritySorterRestriction.update-list-box"/>
     <f:entry title="${%From_Priority}" field="fromPriority">
         <f:select 
         	id="fromPriority" 
         	default="${descriptor.defaultPriority}"
-        	onchange="updateListBox('toPriority','${rootURL}/descriptorByName/jenkins.advancedqueue.jobrestrictions.PrioritySorterRestriction/updateFromPriorityItems?value='+encode(this.value))" />
+            data-descriptor-url="${descriptor.descriptorUrl}"/>
     </f:entry> 
     <f:entry title="${%To_Priority}" field="toPriority">
         <f:select id="toPriority" default="${descriptor.defaultPriority}"/>

--- a/src/main/resources/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestriction/update-list-box.js
+++ b/src/main/resources/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestriction/update-list-box.js
@@ -1,9 +1,9 @@
-Behaviour.specify("#fromPriority", "PrioritySorterRestriction_updateListBox", 0, function(element) {
-    element.addEventListener("change", function(event) {
+Behaviour.specify("#fromPriority", "PrioritySorterRestriction_updateListBox", 0, function (element) {
+    element.addEventListener("change", function (event) {
         const target = event.target;
         const descriptorUrl = target.dataset.descriptorUrl;
         const toPriority = document.querySelector("#toPriority");
 
-        updateListBox(toPriority,`${descriptorUrl}/updateFromPriorityItems?value=${target.value}`);
+        updateListBox(toPriority, `${descriptorUrl}/updateFromPriorityItems?value=${target.value}`);
     });
 });

--- a/src/main/resources/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestriction/update-list-box.js
+++ b/src/main/resources/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestriction/update-list-box.js
@@ -1,0 +1,9 @@
+Behaviour.specify("#fromPriority", "PrioritySorterRestriction_updateListBox", 0, function(element) {
+    element.addEventListener("change", function(event) {
+        const target = event.target;
+        const descriptorUrl = target.dataset.descriptorUrl;
+        const toPriority = document.querySelector("#toPriority");
+
+        updateListBox(toPriority,`${descriptorUrl}/updateFromPriorityItems?value=${target.value}`);
+    });
+});

--- a/src/main/resources/jenkins/advancedqueue/sorter/strategy/MultiBucketStrategy/config.jelly
+++ b/src/main/resources/jenkins/advancedqueue/sorter/strategy/MultiBucketStrategy/config.jelly
@@ -23,12 +23,14 @@
  -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:sl="/hudson/plugins/sidebar_link">
+    <st:adjunct includes="jenkins.advancedqueue.sorter.strategy.MultiBucketStrategy.update-list-box"/>
     <f:entry title="${%Number_of_Priorities}" description="${%The_update_will_do_a_linear_mapping_from_your_current_priorities}" field="numberOfPriorities">
-        <f:textbox id="ps_numberOfPriorities" 
-                   onchange="updateListBox('ps_defaultPriority','descriptorByName/${instance.class.name}/updateDefaultPriorityItems?value='+encode(this.value))"
+        <f:textbox clazz="ps_numberOfPriorities"
+                   data-descriptor-key="${descriptor.key}"
+                   data-descriptor-url="${descriptor.descriptorUrl}"
                    default="${descriptor.defaultPrioritiesNumber}"/>
     </f:entry>
     <f:entry title="${%Default_Priority}" field="defaultPriority">
-        <f:select id="ps_defaultPriority" default="${descriptor.defaultPriority}"/>
+        <f:select id="ps_defaultPriority-${descriptor.key}" default="${descriptor.defaultPriority}"/>
     </f:entry> 
 </j:jelly>

--- a/src/main/resources/jenkins/advancedqueue/sorter/strategy/MultiBucketStrategy/update-list-box.js
+++ b/src/main/resources/jenkins/advancedqueue/sorter/strategy/MultiBucketStrategy/update-list-box.js
@@ -1,0 +1,10 @@
+Behaviour.specify(".ps_numberOfPriorities", "MultiBucketStrategy_updateListBox", 0, function(element) {
+    element.addEventListener("change", function(event) {
+        const target = event.target;
+        const descriptorKey = target.dataset.descriptorKey;
+        const descriptorUrl = target.dataset.descriptorUrl;
+        const defaultPriority = document.querySelector(`#ps_defaultPriority-${descriptorKey}`);
+
+        updateListBox(defaultPriority, `${descriptorUrl}/updateDefaultPriorityItems?value=${target.value}`);
+    });
+});

--- a/src/main/resources/jenkins/advancedqueue/sorter/strategy/MultiBucketStrategy/update-list-box.js
+++ b/src/main/resources/jenkins/advancedqueue/sorter/strategy/MultiBucketStrategy/update-list-box.js
@@ -1,5 +1,5 @@
-Behaviour.specify(".ps_numberOfPriorities", "MultiBucketStrategy_updateListBox", 0, function(element) {
-    element.addEventListener("change", function(event) {
+Behaviour.specify(".ps_numberOfPriorities", "MultiBucketStrategy_updateListBox", 0, function (element) {
+    element.addEventListener("change", function (event) {
         const target = event.target;
         const descriptorKey = target.dataset.descriptorKey;
         const descriptorUrl = target.dataset.descriptorUrl;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-73910

The functionality of updating the values in the dropdown was broken. Seems like the signature of `updateListBox` has changed since the time this code was written. So I've fixed that along with the extraction.

### Testing done

https://www.loom.com/share/414196ed73624dff9770c2882c1ed3a0

https://www.loom.com/share/d42712cdecde4c77a09fb273a5ab4102

https://www.loom.com/share/13c333dfd5054605b1c7cbb46a650a60

https://www.loom.com/share/a118cc996c4a4552a233cf29774430e1

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
