### PR TITLE
Add unit tests for PrioritySorterRestriction class to address JENKINS-69757

### DIFF
--- a/src/test/java/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestrictionTest.java
+++ b/src/test/java/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestrictionTest.java
@@ -19,10 +19,12 @@ class PrioritySorterRestrictionTest {
     private PrioritySorterRestriction restriction;
     private BuildableItem mockedBuildableItem;
     private static final long MOCKED_BUILDABLE_ITEM_ID = 1L;
+    private static final int LOWER_PRIORITY = 1;
+    private static final int UPPER_PRIORITY = 1;
 
     @BeforeEach
     void setUp() {
-        this.restriction = new PrioritySorterRestriction(1, 5);
+        this.restriction = new PrioritySorterRestriction(LOWER_PRIORITY, UPPER_PRIORITY);
         this.mockedBuildableItem = mock(BuildableItem.class);
         when(mockedBuildableItem.getId()).thenReturn(MOCKED_BUILDABLE_ITEM_ID);
     }
@@ -57,7 +59,7 @@ class PrioritySorterRestrictionTest {
             QueueItemCache mockCache = mock(QueueItemCache.class);
             mockedCache.when(QueueItemCache::get).thenReturn(mockCache);
             when(mockCache.getItem(MOCKED_BUILDABLE_ITEM_ID)).thenReturn(mockItemInfo);
-            if (priority >= 1 && priority <= 5)
+            if (priority >= LOWER_PRIORITY && priority <= UPPER_PRIORITY)
                 assertTrue(
                         restriction.canTake(mockedBuildableItem),
                         "Should allow execution when priority is within range.");
@@ -69,11 +71,18 @@ class PrioritySorterRestrictionTest {
     }
 
     @Test
-    void testGetterMethods() {
+    void testCanTake() {
         Run mockedRun = mock(Run.class);
-        restriction = new PrioritySorterRestriction(1, 5);
-        assertEquals(1, restriction.getFromPriority(), "From Priority should be 1");
-        assertEquals(5, restriction.getToPriority(), "To Priority should be 5");
         assertTrue(restriction.canTake(mockedRun), "canTake should return true when passed a Run object.");
+    }
+
+    @Test
+    void testGetFromPriority() {
+        assertEquals(LOWER_PRIORITY, restriction.getFromPriority(), "From Priority should be " + LOWER_PRIORITY);
+    }
+
+    @Test
+    void testGetToPriority() {
+        assertEquals(UPPER_PRIORITY, restriction.getToPriority(), "To Priority should be " + UPPER_PRIORITY);
     }
 }

--- a/src/test/java/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestrictionTest.java
+++ b/src/test/java/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestrictionTest.java
@@ -1,0 +1,76 @@
+package jenkins.advancedqueue.jobrestrictions;
+
+
+import hudson.model.Run;
+import jenkins.advancedqueue.sorter.ItemInfo;
+import jenkins.advancedqueue.sorter.QueueItemCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import java.lang.reflect.Field;
+import static hudson.model.Queue.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PrioritySorterRestrictionTest {
+
+    private PrioritySorterRestriction restriction;
+    private BuildableItem mockedBuildableItem;
+    private static final long MOCKED_BUILDABLE_ITEM_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        this.restriction = new PrioritySorterRestriction(1, 5);
+        this.mockedBuildableItem = mock(BuildableItem.class);
+        when(mockedBuildableItem.getId()).thenReturn(MOCKED_BUILDABLE_ITEM_ID);
+    }
+
+    @Test
+    void testCanTake_MissingItemInfo() throws NoSuchFieldException,IllegalAccessException {
+        Task mockedTask = mock(Task.class);
+        setTaskInMockedBuildableItem(mockedBuildableItem, mockedTask);
+
+        try (MockedStatic<QueueItemCache> mockedQueueItemCache = mockStatic(QueueItemCache.class)) {
+            QueueItemCache mockedItemCache = mock(QueueItemCache.class);
+            mockedQueueItemCache.when(QueueItemCache::get).thenReturn(mockedItemCache);
+            when(mockedItemCache.getItem(MOCKED_BUILDABLE_ITEM_ID)).thenReturn(null);
+            assertTrue(restriction.canTake(mockedBuildableItem));
+        }
+    }
+
+    private void setTaskInMockedBuildableItem(BuildableItem buildableItem, Task task) throws NoSuchFieldException, IllegalAccessException {
+        Field taskField = BuildableItem.class.getField("task");
+        taskField.setAccessible(true);
+        taskField.set(buildableItem, task);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 3, 6})
+    void testCanTake_PriorityRange(int priority) {
+        ItemInfo mockItemInfo = mock(ItemInfo.class);
+        when(mockItemInfo.getPriority()).thenReturn(priority);
+
+        try (MockedStatic<QueueItemCache> mockedCache = mockStatic(QueueItemCache.class)) {
+            QueueItemCache mockCache = mock(QueueItemCache.class);
+            mockedCache.when(QueueItemCache::get).thenReturn(mockCache);
+            when(mockCache.getItem(MOCKED_BUILDABLE_ITEM_ID)).thenReturn(mockItemInfo);
+            if (priority >= 1 && priority <= 5)
+                assertTrue(restriction.canTake(mockedBuildableItem), "Should allow execution when priority is within range.");
+            else
+                assertFalse(restriction.canTake(mockedBuildableItem), "Should not allow execution when priority is outside range.");
+        }
+    }
+
+    @Test
+    void testGetterMethods() {
+        Run mockedRun = mock(Run.class);
+        restriction = new PrioritySorterRestriction(1, 5);
+        assertEquals(1, restriction.getFromPriority(), "From Priority should be 1");
+        assertEquals(5, restriction.getToPriority(), "To Priority should be 5");
+        assertTrue(restriction.canTake(mockedRun), "canTake should return true when passed a Run object.");
+    }
+}
+
+

--- a/src/test/java/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestrictionTest.java
+++ b/src/test/java/jenkins/advancedqueue/jobrestrictions/PrioritySorterRestrictionTest.java
@@ -1,7 +1,11 @@
 package jenkins.advancedqueue.jobrestrictions;
 
+import static hudson.model.Queue.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import hudson.model.Run;
+import java.lang.reflect.Field;
 import jenkins.advancedqueue.sorter.ItemInfo;
 import jenkins.advancedqueue.sorter.QueueItemCache;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,10 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
-import java.lang.reflect.Field;
-import static hudson.model.Queue.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class PrioritySorterRestrictionTest {
 
@@ -28,7 +28,7 @@ class PrioritySorterRestrictionTest {
     }
 
     @Test
-    void testCanTake_MissingItemInfo() throws NoSuchFieldException,IllegalAccessException {
+    void testCanTake_MissingItemInfo() throws NoSuchFieldException, IllegalAccessException {
         Task mockedTask = mock(Task.class);
         setTaskInMockedBuildableItem(mockedBuildableItem, mockedTask);
 
@@ -40,7 +40,8 @@ class PrioritySorterRestrictionTest {
         }
     }
 
-    private void setTaskInMockedBuildableItem(BuildableItem buildableItem, Task task) throws NoSuchFieldException, IllegalAccessException {
+    private void setTaskInMockedBuildableItem(BuildableItem buildableItem, Task task)
+            throws NoSuchFieldException, IllegalAccessException {
         Field taskField = BuildableItem.class.getField("task");
         taskField.setAccessible(true);
         taskField.set(buildableItem, task);
@@ -57,9 +58,13 @@ class PrioritySorterRestrictionTest {
             mockedCache.when(QueueItemCache::get).thenReturn(mockCache);
             when(mockCache.getItem(MOCKED_BUILDABLE_ITEM_ID)).thenReturn(mockItemInfo);
             if (priority >= 1 && priority <= 5)
-                assertTrue(restriction.canTake(mockedBuildableItem), "Should allow execution when priority is within range.");
+                assertTrue(
+                        restriction.canTake(mockedBuildableItem),
+                        "Should allow execution when priority is within range.");
             else
-                assertFalse(restriction.canTake(mockedBuildableItem), "Should not allow execution when priority is outside range.");
+                assertFalse(
+                        restriction.canTake(mockedBuildableItem),
+                        "Should not allow execution when priority is outside range.");
         }
     }
 
@@ -72,5 +77,3 @@ class PrioritySorterRestrictionTest {
         assertTrue(restriction.canTake(mockedRun), "canTake should return true when passed a Run object.");
     }
 }
-
-


### PR DESCRIPTION
This pull request introduces unit tests for the `PrioritySorterRestriction` class to address the issue outlined in [JENKINS-69757](https://issues.jenkins.io/browse/JENKINS-69757). 
These tests ensure the class functions correctly and handles various scenarios, such as missing `ItemInfo` and priority range validations.
These tests increase the code coverage of the code-base.


### Testing done
- Automated tests were implemented to ensure complete coverage of the `PrioritySorterRestriction` logic:
     - `testCanTake_MissingItemInfo`: Verifies behavior when `ItemInfo` is absent in the `QueueItemCache`.
     - `testCanTake_PriorityRange`: Tests `canTake` behavior for different priority values, validating edge conditions.
     - `testGetterMethods`: Ensures the correctness of getter methods and that `canTake` works with `Run` objects.
![Screenshot From 2024-11-24 19-51-04](https://github.com/user-attachments/assets/a8a2f9b1-921e-46ea-8180-353ef209bbbe)
![Screenshot From 2024-11-24 20-38-04](https://github.com/user-attachments/assets/65c8d7ad-f339-4022-841b-50c13b3e2233)



### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

