### PR TITLE
[JENKINS-69757] - Improving test coverage for health strategy

### DIFF
--- a/src/test/java/jenkins/advancedqueue/priority/strategy/HealthStrategyTest.java
+++ b/src/test/java/jenkins/advancedqueue/priority/strategy/HealthStrategyTest.java
@@ -1,0 +1,300 @@
+package jenkins.advancedqueue.priority.strategy;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import hudson.model.HealthReport;
+import hudson.model.Job;
+import hudson.model.Queue.BuildableItem;
+import hudson.model.Queue.Task;
+import hudson.util.RunList;
+import java.lang.reflect.Field;
+import java.util.Iterator;
+import org.junit.Test;
+
+public class HealthStrategyTest {
+    private BuildableItem mockedBuildableItem;
+    private Job<?, ?> mockedJob;
+
+    @Test
+    public void assertHealthOver80SameSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_OVER_80");
+        setMockedJobHealthTo(85);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealthOver80SameSelectionFails() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_OVER_80");
+        setMockedJobHealthTo(75);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealthOver80BetterSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "BETTER", "HEALTH_OVER_80");
+        setMockedJobHealthTo(85);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealthOver80BetterSelectionFails() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "BETTER", "HEALTH_OVER_80");
+        setMockedJobHealthTo(75);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth61To80SameSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_61_TO_80");
+        setMockedJobHealthTo(75);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth61To80SameSelectionFailsWithGreater() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_61_TO_80");
+        setMockedJobHealthTo(81);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth61To80SameSelectionFailsWithLower() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_61_TO_80");
+        setMockedJobHealthTo(60);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth61To80BetterSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "BETTER", "HEALTH_61_TO_80");
+        setMockedJobHealthTo(75);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth61To80BetterSelectionFails() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "BETTER", "HEALTH_61_TO_80");
+        setMockedJobHealthTo(60);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth61To80WorseSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "WORSE", "HEALTH_61_TO_80");
+        setMockedJobHealthTo(80);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth61To80WorseSelectionFails() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "WORSE", "HEALTH_61_TO_80");
+        setMockedJobHealthTo(81);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth41to60SameSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_41_TO_60");
+        setMockedJobHealthTo(55);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth41to60SameSelectionFailsWithGreater() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_41_TO_60");
+        setMockedJobHealthTo(61);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth41to60SameSelectionFailsWithLower() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_41_TO_60");
+        setMockedJobHealthTo(40);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth41to60BetterSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "BETTER", "HEALTH_41_TO_60");
+        setMockedJobHealthTo(50);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth41to60BetterSelectionFails() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "BETTER", "HEALTH_41_TO_60");
+        setMockedJobHealthTo(40);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth41to60WorseSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "WORSE", "HEALTH_41_TO_60");
+        setMockedJobHealthTo(60);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth41to60WorseSelectionFails() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "WORSE", "HEALTH_41_TO_60");
+        setMockedJobHealthTo(61);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth21to40SameSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_21_TO_40");
+        setMockedJobHealthTo(35);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth21to40SameSelectionFailsWithGreater() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_21_TO_40");
+        setMockedJobHealthTo(41);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth21to40SameSelectionFailsWithLower() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_21_TO_40");
+        setMockedJobHealthTo(20);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth21to40BetterSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "BETTER", "HEALTH_21_TO_40");
+        setMockedJobHealthTo(30);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth21to40BetterSelectionFails() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "BETTER", "HEALTH_21_TO_40");
+        setMockedJobHealthTo(20);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth21to40WorseSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "WORSE", "HEALTH_21_TO_40");
+        setMockedJobHealthTo(40);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth21to40WorseSelectionFails() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "WORSE", "HEALTH_21_TO_40");
+        setMockedJobHealthTo(41);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth0to20SameSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_0_TO_20");
+        setMockedJobHealthTo(15);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth0to20SameSelectionFailsWithGreater() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_0_TO_20");
+        setMockedJobHealthTo(21);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth0to20SameSelectionFailsWithLower() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "SAME", "HEALTH_0_TO_20");
+        setMockedJobHealthTo(-1);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth0to20BetterSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "BETTER", "HEALTH_0_TO_20");
+        setMockedJobHealthTo(15);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth0to20BetterSelectionFails() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "BETTER", "HEALTH_0_TO_20");
+        setMockedJobHealthTo(-1);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth0to20WorseSelectionConcludes() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "WORSE", "HEALTH_0_TO_20");
+        setMockedJobHealthTo(20);
+        initializeJobRunList();
+        assertTrue(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    @Test
+    public void assertHealth0to20WorseSelectionFails() throws NoSuchFieldException, IllegalAccessException {
+        HealthStrategy strategy = new HealthStrategy(0, "WORSE", "HEALTH_0_TO_20");
+        setMockedJobHealthTo(21);
+        initializeJobRunList();
+        assertFalse(strategy.isApplicable(this.mockedBuildableItem));
+    }
+
+    private void setMockedJobHealthTo(int health) throws NoSuchFieldException, IllegalAccessException {
+        this.mockedBuildableItem = mock(BuildableItem.class);
+        this.mockedJob = mock(Job.class, withSettings().extraInterfaces(Task.class));
+        setTaskInMockedBuildableItem(this.mockedBuildableItem, (Task) this.mockedJob);
+        HealthReport mockedHealthReport = mock(HealthReport.class);
+        when(this.mockedJob.getBuildHealth()).thenReturn(mockedHealthReport);
+        when(mockedHealthReport.getScore()).thenReturn(health);
+    }
+
+    private void initializeJobRunList() {
+        // These mocks are used to avoid returning false instantly as per HealthStrategy#isApplicable:68
+        when(this.mockedJob.getBuilds()).thenReturn(mock(RunList.class));
+        when(this.mockedJob.getBuilds().iterator()).thenReturn(mock(Iterator.class));
+        when(this.mockedJob.getBuilds().iterator().hasNext()).thenReturn(true);
+    }
+
+    private void setTaskInMockedBuildableItem(BuildableItem buildableItem, Task task)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field taskField = BuildableItem.class.getField("task");
+        taskField.setAccessible(true);
+        taskField.set(buildableItem, task);
+    }
+}


### PR DESCRIPTION
This Pull Request aims to improve test coverage for the plugin (as described [here](https://issues.jenkins.io/browse/JENKINS-69757)) by creating tests for the priority package.

The test coverage for HealthStrategy class was:

![image](https://github.com/user-attachments/assets/7057c8a4-e6e7-40b4-9f87-ebf8c58e9b5a)

When this PR closes, the coverage will be:

![image](https://github.com/user-attachments/assets/b151aa58-3feb-4180-8f71-62b5b90ec199)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
