### PR TITLE
Do not require TestRunListener.init() before use

### DIFF
--- a/src/test/java/jenkins/advancedqueue/testutil/TestRunListener.java
+++ b/src/test/java/jenkins/advancedqueue/testutil/TestRunListener.java
@@ -22,7 +22,7 @@ public class TestRunListener extends RunListener<Run> {
 
     public static void init(ExpectedItem... expected) {
         TestRunListener.expected = expected;
-        actual = new ArrayList<ItemInfo>(expected.length);
+        actual = new ArrayList<>(expected.length);
     }
 
     @Override
@@ -30,6 +30,11 @@ public class TestRunListener extends RunListener<Run> {
         LOGGER.info("ON STARTED: " + r.getParent().getName());
         try {
             ItemInfo item = QueueItemCache.get().getItem(r.getParent().getName());
+            if (actual == null) {
+                // Init was not called, initialize
+                TestRunListener.expected = null;
+                actual = new ArrayList<>();
+            }
             actual.add(item);
         } catch (Throwable e) {
             LOGGER.log(Level.INFO, "###########", e);


### PR DESCRIPTION
## Do not require TestRunListener.init() before use

New tests do not need to initialize the test run listener

### Testing done

Confirmed that existing tests pass and new tests no longer report a null pointer exception to the log.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
