### PR TITLE
Added tests for JobInclusionFolderProperty class

### DIFF
--- a/src/test/java/jenkins/advancedqueue/jobinclusion/strategy/JobInclusionFolderPropertyTest.java
+++ b/src/test/java/jenkins/advancedqueue/jobinclusion/strategy/JobInclusionFolderPropertyTest.java
@@ -1,0 +1,55 @@
+package jenkins.advancedqueue.jobinclusion.strategy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class JobInclusionFolderPropertyTest {
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    private JobInclusionFolderProperty property;
+    private JobInclusionFolderProperty.DescriptorImpl descriptor;
+
+    @Before
+    public void setup() {
+        property = new JobInclusionFolderProperty(true, "TestJobGroup");
+        descriptor = new JobInclusionFolderProperty.DescriptorImpl();
+    }
+
+    @Test
+    public void getJobGroupNameTest() {
+        assertEquals("TestJobGroup", property.getJobGroupName());
+    }
+
+    @Test
+    public void isUseJobGroupTest() {
+        assertTrue(property.isUseJobGroup());
+    }
+
+    @Test
+    public void getDescriptorTest() {
+        assertNotNull(property.getDescriptor());
+    }
+
+    @Test
+    public void getDisplayNameTest() {
+        assertEquals("XXX", descriptor.getDisplayName());
+    }
+
+    @Test
+    public void getJobGroupsTest() {
+        assertNotNull(descriptor.getJobGroups());
+    }
+
+    @Test
+    public void isUsedTest() {
+        assertFalse(descriptor.isUsed());
+    }
+}


### PR DESCRIPTION
Part of [JENKINS-69757](https://issues.jenkins.io/browse/JENKINS-69757).
Added tests for the `JobInclusionFolderProperty` class.

Test coverage before:
![nblp1](https://github.com/user-attachments/assets/bbf07816-885f-4058-88d6-12185b329dd1)
Test coverage after:
![nblp2](https://github.com/user-attachments/assets/4ea1c7e9-e660-4f79-8515-96eb534cc2fc)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
