### PR TITLE
Silence XREF warning in Maven output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,9 @@
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
+    <!-- Silence Maven XREF warning, don't need hyperlinked source code -->
+    <!-- https://stackoverflow.com/questions/12038238/unable-to-locate-source-xref-to-link-to -->
+    <linkXRef>false</linkXRef>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Silence XREF warning in Maven output

The [stackoverflow article](https://stackoverflow.com/questions/12038238/unable-to-locate-source-xref-to-link-to) describes the rationale.  We don't need linked source code reports, so it is safe to globally disable `linkXRef`.

### Testing done

Confirmed that `mvn verify` before this change outputs 3 messages warning about XREF and that after this change those messages are not shown.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
