### PR TITLE
Added tests for JobPropertyStrategy class

### DIFF
--- a/src/main/java/jenkins/advancedqueue/priority/strategy/JobPropertyStrategy.java
+++ b/src/main/java/jenkins/advancedqueue/priority/strategy/JobPropertyStrategy.java
@@ -51,7 +51,7 @@ public class JobPropertyStrategy extends AbstractDynamicPriorityStrategy {
 
     @CheckForNull
     private Integer getPriorityInternal(Queue.Item item) {
-        if (item.task instanceof Job<?, ?>) {
+        if (item != null && item.task instanceof Job<?, ?>) {
             Job<?, ?> job = (Job<?, ?>) item.task;
             PriorityJobProperty priorityProperty = job.getProperty(PriorityJobProperty.class);
             if (priorityProperty != null && priorityProperty.getUseJobPriority()) {

--- a/src/test/java/jenkins/advancedqueue/priority/strategy/JobPropertyStrategyTest.java
+++ b/src/test/java/jenkins/advancedqueue/priority/strategy/JobPropertyStrategyTest.java
@@ -1,36 +1,113 @@
 package jenkins.advancedqueue.priority.strategy;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertTrue;
 
+import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
-import org.junit.Rule;
+import jenkins.advancedqueue.PrioritySorterConfiguration;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class JobPropertyStrategyTest {
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    private static FreeStyleProject project;
+    private static FreeStyleProject projectWithProperty;
+    private static FreeStyleProject projectWithUnusedProperty;
+
+    private static int defaultPriority;
+    private static int jobPriority;
+
+    private JobPropertyStrategy strategy;
+
+    @BeforeClass
+    public static void startProject() throws Exception {
+        project = j.createFreeStyleProject("no-property");
+        // Schedule initial delay so job is queued but does not run
+        project.scheduleBuild2(600);
+    }
+
+    @BeforeClass
+    public static void startProjectWithProperty() throws Exception {
+        boolean useJobPriority = true;
+        PriorityJobProperty property = new PriorityJobProperty(useJobPriority, jobPriority);
+        projectWithProperty = j.createFreeStyleProject("with-property");
+        projectWithProperty.addProperty(property);
+        // Schedule initial delay so job is queued but does not run
+        projectWithProperty.scheduleBuild2(600);
+    }
+
+    @BeforeClass
+    public static void startProjectWithUnusedProperty() throws Exception {
+        boolean useJobPriority = false;
+        PriorityJobProperty property = new PriorityJobProperty(useJobPriority, jobPriority);
+        projectWithUnusedProperty = j.createFreeStyleProject("with-unused-property");
+        projectWithUnusedProperty.addProperty(property);
+        // Schedule initial delay so job is queued but does not run
+        projectWithUnusedProperty.scheduleBuild2(600);
+    }
+
+    @BeforeClass
+    public static void setPriorities() {
+        defaultPriority = PrioritySorterConfiguration.get().getStrategy().getDefaultPriority();
+        jobPriority = defaultPriority - 1;
+    }
+
+    @Before
+    public void createStrategy() {
+        strategy = new JobPropertyStrategy();
+    }
 
     @Test
     public void isApplicableTestWhengetPriorityInternalReturnsNull() {
-        JobPropertyStrategy strategy = new JobPropertyStrategy();
-        Queue.Item mockItem = mock(Queue.Item.class);
-        boolean result = strategy.isApplicable(mockItem);
-        // the result is false since mockItem.task instanceof Job<?, ?> does not hold
-        assertFalse(result);
+        Queue.Item nullItem = null;
+        assertFalse(strategy.isApplicable(nullItem));
+        assertFalse(strategy.isApplicable(null));
+    }
+
+    @Test
+    public void isApplicableWhenFreeStyleProject() {
+        assertFalse(strategy.isApplicable(project.getQueueItem()));
+    }
+
+    @Test
+    public void isApplicableWhenFreeStyleProjectWithPriorityProperty() {
+        assertTrue(strategy.isApplicable(projectWithProperty.getQueueItem()));
+    }
+
+    @Test
+    public void isApplicableWhenFreeStyleProjectWithUnusedPriorityProperty() {
+        assertFalse(strategy.isApplicable(projectWithUnusedProperty.getQueueItem()));
     }
 
     @Test
     public void getPriorityTestWhengetPriorityInternalReturnsNull() {
-        JobPropertyStrategy strategy = new JobPropertyStrategy();
-        Queue.Item mockItem = mock(Queue.Item.class);
-        int priority = strategy.getPriority(mockItem);
-        assertNotNull(priority);
-        // priority is 3 when mockItem.task instanceof Job<?, ?> does not hold
-        assertEquals(priority, 3);
+        Queue.Item nullItem = null;
+        // priority is 3 when item is null
+        assertThat(strategy.getPriority(nullItem), is(defaultPriority));
+        assertThat(strategy.getPriority(null), is(defaultPriority));
+    }
+
+    @Test
+    public void getPriorityTestFreeStyleProject() {
+        assertThat(strategy.getPriority(project.getQueueItem()), is(defaultPriority));
+    }
+
+    @Test
+    public void getPriorityTestFreeStyleProjectWithPriorityProperty() {
+        assertThat(strategy.getPriority(projectWithProperty.getQueueItem()), is(jobPriority));
+    }
+
+    @Test
+    public void getPriorityTestFreeStyleProjectWithUnusedPriorityProperty() {
+        assertThat(strategy.getPriority(projectWithUnusedProperty.getQueueItem()), is(defaultPriority));
     }
 }

--- a/src/test/java/jenkins/advancedqueue/priority/strategy/JobPropertyStrategyTest.java
+++ b/src/test/java/jenkins/advancedqueue/priority/strategy/JobPropertyStrategyTest.java
@@ -1,0 +1,36 @@
+package jenkins.advancedqueue.priority.strategy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import hudson.model.Queue;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class JobPropertyStrategyTest {
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Test
+    public void isApplicableTestWhengetPriorityInternalReturnsNull() {
+        JobPropertyStrategy strategy = new JobPropertyStrategy();
+        Queue.Item mockItem = mock(Queue.Item.class);
+        boolean result = strategy.isApplicable(mockItem);
+        // the result is false since mockItem.task instanceof Job<?, ?> does not hold
+        assertFalse(result);
+    }
+
+    @Test
+    public void getPriorityTestWhengetPriorityInternalReturnsNull() {
+        JobPropertyStrategy strategy = new JobPropertyStrategy();
+        Queue.Item mockItem = mock(Queue.Item.class);
+        int priority = strategy.getPriority(mockItem);
+        assertNotNull(priority);
+        // priority is 3 when mockItem.task instanceof Job<?, ?> does not hold
+        assertEquals(priority, 3);
+    }
+}


### PR DESCRIPTION
Part of [JENKINS-69757](https://issues.jenkins.io/browse/JENKINS-69757)
Added tests for the `JobPropertyStrategy` class. The tests added cover the case when the `WhengetPriorityInternal` function returns null.

Test coverage before:
![nblp2](https://github.com/user-attachments/assets/079075fa-c5a8-41d0-99f1-150776e1dd71)
Test coverage after:
![nblp1](https://github.com/user-attachments/assets/dc56b6b5-3a9e-4b61-93c9-9a23ed2b170e)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
