### PR TITLE
Fix link to issue reporting guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,4 +149,4 @@ Steps to test a pull request build are:
 ## Reporting Issues
 
 Report issues in the [Jenkins issue tracker](https://www.jenkins.io/participate/report-issue/redirect/#15771).
-Please use the link:https://www.jenkins.io/participate/report-issue/["How to Report an Issue"] guidelines when reporting issues.
+Please use the ["How to Report an Issue"](https://www.jenkins.io/participate/report-issue/) guidelines when reporting issues.


### PR DESCRIPTION
## Fix link to issue reporting guidelines

Was using Asciidoc syntax instead of Markdown syntax.

### Testing done

Checked in earlier pull requests to other repositories.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
