### PR TITLE
Support prioritizing parallel stages by parent build start time

### DIFF
--- a/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorter.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorter.java
@@ -52,7 +52,7 @@ public class AdvancedQueueSorter extends QueueSorter {
 
     private static final Logger LOGGER = Logger.getLogger("PrioritySorter.Queue.Sorter");
     private static final String PIPELINE_PLACEHOLDER_TASK_CLASS =
-      "org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask";
+            "org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask";
 
     public AdvancedQueueSorter() {}
 
@@ -124,9 +124,9 @@ public class AdvancedQueueSorter extends QueueSorter {
                 }
             } catch (ReflectiveOperationException | SecurityException e) {
                 LOGGER.log(
-                  Level.FINEST,
-                  "Failed to resolve pipeline parent run start time due to reflection/invocation error",
-                  e);
+                        Level.FINEST,
+                        "Failed to resolve pipeline parent run start time due to reflection/invocation error",
+                        e);
             }
         }
 

--- a/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorter.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/AdvancedQueueSorter.java
@@ -31,7 +31,9 @@ import hudson.model.Queue;
 import hudson.model.Queue.BuildableItem;
 import hudson.model.Queue.Item;
 import hudson.model.Queue.LeftItem;
+import hudson.model.Run;
 import hudson.model.queue.QueueSorter;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -49,6 +51,8 @@ import jenkins.advancedqueue.PrioritySorterConfiguration;
 public class AdvancedQueueSorter extends QueueSorter {
 
     private static final Logger LOGGER = Logger.getLogger("PrioritySorter.Queue.Sorter");
+    private static final String PIPELINE_PLACEHOLDER_TASK_CLASS =
+      "org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask";
 
     public AdvancedQueueSorter() {}
 
@@ -96,6 +100,39 @@ public class AdvancedQueueSorter extends QueueSorter {
         }
     }
 
+    private Long resolveParentStartTime(Item item) {
+        if (item == null) {
+            return null;
+        }
+
+        Queue.Task task = item.task;
+
+        if (PIPELINE_PLACEHOLDER_TASK_CLASS.equals(task.getClass().getName())) {
+            try {
+                Object run;
+
+                try {
+                    Method getOwnerExecutable = task.getClass().getMethod("getOwnerExecutable");
+                    run = getOwnerExecutable.invoke(task);
+                } catch (NoSuchMethodException e) {
+                    Method runMethod = task.getClass().getMethod("run");
+                    run = runMethod.invoke(task);
+                }
+
+                if (run instanceof hudson.model.Run) {
+                    return ((Run<?, ?>) run).getStartTimeInMillis();
+                }
+            } catch (ReflectiveOperationException | SecurityException e) {
+                LOGGER.log(
+                  Level.FINEST,
+                  "Failed to resolve pipeline parent run start time due to reflection/invocation error",
+                  e);
+            }
+        }
+
+        return null;
+    }
+
     @Override
     public void sortBuildableItems(List<BuildableItem> items) {
         sortNotWaitingItems(items);
@@ -112,6 +149,10 @@ public class AdvancedQueueSorter extends QueueSorter {
         ItemInfo itemInfo = new ItemInfo(item);
         PriorityConfiguration.get().getPriority(item, itemInfo);
         prioritySorterStrategy.onNewItem(item, itemInfo);
+        Long parentStartTime = resolveParentStartTime(item);
+        if (parentStartTime != null) {
+            itemInfo.setParentStartTime(parentStartTime);
+        }
         QueueItemCache.get().addItem(itemInfo);
         logNewItem(itemInfo);
     }

--- a/src/main/java/jenkins/advancedqueue/sorter/ItemInfo.java
+++ b/src/main/java/jenkins/advancedqueue/sorter/ItemInfo.java
@@ -23,6 +23,7 @@
  */
 package jenkins.advancedqueue.sorter;
 
+import static java.lang.Long.compare;
 import static jenkins.advancedqueue.ItemTransitionLogger.logBlockedItem;
 import static jenkins.advancedqueue.ItemTransitionLogger.logBuilableItem;
 
@@ -56,6 +57,8 @@ public class ItemInfo
     private String jobName;
 
     private float weight;
+
+    private Long parentStartTime = null;
 
     private int priority;
 
@@ -152,13 +155,24 @@ public class ItemInfo
 
     @Override
     public int compareTo(ItemInfo o) {
-        if (this.getWeight() == o.getWeight()) {
-            if (this.getSortableInQueueSince() == o.getSortableInQueueSince()) {
-                return Long.compare(this.getItemId(), o.getItemId());
-            }
-            return Long.compare(this.getSortableInQueueSince(), o.getSortableInQueueSince());
+        int weightCompare = Float.compare(this.getWeight(), o.getWeight());
+        if (weightCompare != 0) {
+            return weightCompare;
         }
-        return Float.compare(this.getWeight(), o.getWeight());
+
+        if (this.parentStartTime != null && o.parentStartTime != null) {
+            int parentTimeCompare = compare(this.parentStartTime, o.parentStartTime);
+            if (parentTimeCompare != 0) {
+                return parentTimeCompare;
+            }
+        }
+
+        int queueTimeCompare = compare(this.getSortableInQueueSince(), o.getSortableInQueueSince());
+        if (queueTimeCompare != 0) {
+            return queueTimeCompare;
+        }
+
+        return compare(this.getItemId(), o.getItemId());
     }
 
     @Override
@@ -179,6 +193,7 @@ public class ItemInfo
                 priorityStrategy,
                 jobName,
                 weight,
+                parentStartTime,
                 priority,
                 itemStatus,
                 decisionLog);
@@ -208,5 +223,9 @@ public class ItemInfo
             return log;
         }
         return ("%" + spaces + "s%s").formatted("", log);
+    }
+
+    public void setParentStartTime(Long parentStartTime) {
+        this.parentStartTime = parentStartTime;
     }
 }

--- a/src/test/java/jenkins/advancedqueue/sorter/AdvancedQueueSorterTest.java
+++ b/src/test/java/jenkins/advancedqueue/sorter/AdvancedQueueSorterTest.java
@@ -23,6 +23,8 @@
  */
 package jenkins.advancedqueue.sorter;
 
+import static java.lang.System.nanoTime;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -85,6 +87,138 @@ class AdvancedQueueSorterTest {
         if (handler != null && logger != null) {
             logger.removeHandler(handler);
         }
+    }
+
+    @Test
+    public void testPipelineParentStartTimeTieBreaker() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("pipe1-" + nanoTime());
+        FreeStyleProject p2 = jenkins.createFreeStyleProject("pipe2-" + nanoTime());
+
+       Queue.BuildableItem q1 =
+                new Queue.BuildableItem(new Queue.WaitingItem(Calendar.getInstance(), p1, emptyList()));
+        Queue.BuildableItem q2 =
+                new Queue.BuildableItem(new Queue.WaitingItem(Calendar.getInstance(), p2, emptyList()));
+
+        ItemInfo info1 = new ItemInfo(q1);
+        info1.setWeightSelection(5.0f);
+
+        ItemInfo info2 = new ItemInfo(q2);
+        info2.setWeightSelection(5.0f);
+
+        info1.setParentStartTime(100L);
+        info2.setParentStartTime(200L);
+
+        assertTrue(info1.compareTo(info2) < 0, "Older pipeline stage should be sorted first");
+        assertTrue(info2.compareTo(info1) > 0, "Newer pipeline stage should be sorted later");
+    }
+
+    @Test
+    public void testPipelineIsolationIgnoresNonPipelineJobs() throws Exception {
+        FreeStyleProject pipelineJob = jenkins.createFreeStyleProject("pipeline-stage-" + nanoTime());
+        FreeStyleProject freestyleJob = jenkins.createFreeStyleProject("freestyle-job-" + nanoTime());
+
+        Calendar oldTime = Calendar.getInstance();
+        oldTime.setTimeInMillis(1000L);
+
+        Calendar newTime = Calendar.getInstance();
+        newTime.setTimeInMillis(2000L);
+
+        Queue.BuildableItem qFree =
+                new Queue.BuildableItem(new Queue.WaitingItem(oldTime, freestyleJob, emptyList()));
+
+        Queue.BuildableItem qPipe =
+                new Queue.BuildableItem(new Queue.WaitingItem(newTime, pipelineJob, emptyList()));
+
+        ItemInfo infoFree = new ItemInfo(qFree);
+        infoFree.setWeightSelection(5.0f);
+        infoFree.setParentStartTime(null);
+
+        ItemInfo infoPipe = new ItemInfo(qPipe);
+        infoPipe.setWeightSelection(5.0f);
+        infoPipe.setParentStartTime(500L);
+
+        assertTrue(
+                infoFree.compareTo(infoPipe) < 0,
+                "Freestyle job should win based on earlier queue time, strictly ignoring pipeline parent times");
+        assertTrue(infoPipe.compareTo(infoFree) > 0, "Pipeline job should be sorted later based on queue ingress time");
+    }
+
+    @Test
+    public void testWeightOverridesParentStartTime() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("p1-" + nanoTime());
+        FreeStyleProject p2 = jenkins.createFreeStyleProject("p2-" + nanoTime());
+
+        Queue.BuildableItem q1 =
+                new Queue.BuildableItem(new Queue.WaitingItem(Calendar.getInstance(), p1, emptyList()));
+        Queue.BuildableItem q2 =
+                new Queue.BuildableItem(new Queue.WaitingItem(Calendar.getInstance(), p2, emptyList()));
+
+        ItemInfo info1 = new ItemInfo(q1);
+        info1.setWeightSelection(1.0f);
+        info1.setParentStartTime(1000L);
+
+        ItemInfo info2 = new ItemInfo(q2);
+        info2.setWeightSelection(10.0f);
+        info2.setParentStartTime(100L);
+
+        int weightCompare = Float.compare(1.0f, 10.0f);
+        assertEquals(
+                weightCompare,
+                info1.compareTo(info2),
+                "Primary strategy weight should always take precedence over pipeline tie-breakers");
+    }
+
+    @Test
+    public void testQueueTimeUsedWhenParentStartTimesMatch() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("same-pipe-1-" + nanoTime());
+        FreeStyleProject p2 = jenkins.createFreeStyleProject("same-pipe-2-" + nanoTime());
+
+        Calendar oldTime = Calendar.getInstance();
+        oldTime.setTimeInMillis(1000L);
+        Calendar newTime = Calendar.getInstance();
+        newTime.setTimeInMillis(2000L);
+
+        Queue.BuildableItem q1 = new Queue.BuildableItem(new Queue.WaitingItem(oldTime, p1, emptyList()));
+
+        Queue.BuildableItem q2 = new Queue.BuildableItem(new Queue.WaitingItem(newTime, p2, emptyList()));
+
+        ItemInfo info1 = new ItemInfo(q1);
+        info1.setWeightSelection(5.0f);
+        info1.setParentStartTime(100L);
+
+        ItemInfo info2 = new ItemInfo(q2);
+        info2.setWeightSelection(5.0f);
+        info2.setParentStartTime(100L);
+
+        assertTrue(info1.compareTo(info2) < 0, "Earlier queue time should win when parent start times are identical");
+        assertTrue(info2.compareTo(info1) > 0, "Later queue time should lose when parent start times are identical");
+    }
+
+    @Test
+    public void testNullParentStartTimesUseQueueTime() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("freestyle-1-" + nanoTime());
+        FreeStyleProject p2 = jenkins.createFreeStyleProject("freestyle-2-" + nanoTime());
+
+        Calendar oldTime = Calendar.getInstance();
+        oldTime.setTimeInMillis(1000L);
+        Calendar newTime = Calendar.getInstance();
+        newTime.setTimeInMillis(2000L);
+
+
+        Queue.BuildableItem q1 = new Queue.BuildableItem(new Queue.WaitingItem(oldTime, p1, emptyList()));
+
+        Queue.BuildableItem q2 = new Queue.BuildableItem(new Queue.WaitingItem(newTime, p2, emptyList()));
+
+        ItemInfo info1 = new ItemInfo(q1);
+        info1.setWeightSelection(5.0f);
+        info1.setParentStartTime(null);
+
+        ItemInfo info2 = new ItemInfo(q2);
+        info2.setWeightSelection(5.0f);
+        info2.setParentStartTime(null);
+
+        assertTrue(info1.compareTo(info2) < 0, "Earlier queue time should win when both parent start times are null");
+        assertTrue(info2.compareTo(info1) > 0, "Later queue time should lose when both parent start times are null");
     }
 
     @Test

--- a/src/test/java/jenkins/advancedqueue/sorter/AdvancedQueueSorterTest.java
+++ b/src/test/java/jenkins/advancedqueue/sorter/AdvancedQueueSorterTest.java
@@ -94,7 +94,7 @@ class AdvancedQueueSorterTest {
         FreeStyleProject p1 = jenkins.createFreeStyleProject("pipe1-" + nanoTime());
         FreeStyleProject p2 = jenkins.createFreeStyleProject("pipe2-" + nanoTime());
 
-       Queue.BuildableItem q1 =
+        Queue.BuildableItem q1 =
                 new Queue.BuildableItem(new Queue.WaitingItem(Calendar.getInstance(), p1, emptyList()));
         Queue.BuildableItem q2 =
                 new Queue.BuildableItem(new Queue.WaitingItem(Calendar.getInstance(), p2, emptyList()));
@@ -123,11 +123,9 @@ class AdvancedQueueSorterTest {
         Calendar newTime = Calendar.getInstance();
         newTime.setTimeInMillis(2000L);
 
-        Queue.BuildableItem qFree =
-                new Queue.BuildableItem(new Queue.WaitingItem(oldTime, freestyleJob, emptyList()));
+        Queue.BuildableItem qFree = new Queue.BuildableItem(new Queue.WaitingItem(oldTime, freestyleJob, emptyList()));
 
-        Queue.BuildableItem qPipe =
-                new Queue.BuildableItem(new Queue.WaitingItem(newTime, pipelineJob, emptyList()));
+        Queue.BuildableItem qPipe = new Queue.BuildableItem(new Queue.WaitingItem(newTime, pipelineJob, emptyList()));
 
         ItemInfo infoFree = new ItemInfo(qFree);
         infoFree.setWeightSelection(5.0f);
@@ -203,7 +201,6 @@ class AdvancedQueueSorterTest {
         oldTime.setTimeInMillis(1000L);
         Calendar newTime = Calendar.getInstance();
         newTime.setTimeInMillis(2000L);
-
 
         Queue.BuildableItem q1 = new Queue.BuildableItem(new Queue.WaitingItem(oldTime, p1, emptyList()));
 


### PR DESCRIPTION
Fixes #625

Allow queued Pipeline parallel stages to be prioritized by their parent build's start time. This allows older Pipeline builds to complete before newer builds that are contending for executors, reducing the number of partially completed builds waiting for executors. The change preserves the existing ordering for non-Pipeline jobs and falls back to the current queue-time behavior when the parent build cannot be determined.

### Testing done

Add tests covering the new parent build start time tie-breaker, fallback behavior, and precedence relative to existing weight-based ordering.

Manually verified by reproducing the reported scenario on a Jenkins instance with a single executor and a Pipeline containing parallel stages. Without this change, queued parallel-stage tasks from newer builds could interleave with those from older builds. With this change, parallel-stage tasks are scheduled according to their parent build start time, allowing older builds to complete before newer ones when priorities and weights are equal.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
